### PR TITLE
Update replace-function.md

### DIFF
--- a/Language/Reference/User-Interface-Help/replace-function.md
+++ b/Language/Reference/User-Interface-Help/replace-function.md
@@ -14,7 +14,7 @@ ms.date: 06/08/2017
 
 
  **Description**
-Returns a string in which a specified substring has been replaced with another substring a specified number of times.
+Returns a string, which is a substring of a string expression beginning at the start position (defaults to 1), in which a specified substring has been replaced with another substring a specified number of times.
 
 ## Syntax
 
@@ -27,7 +27,7 @@ The  **Replace** function syntax has these[named arguments](../../Glossary/vbe-g
 |**_expression_**|Required. [String expression](../../Glossary/vbe-glossary.md#string-expression) containing substring to replace.|
 |**_find_**|Required. Substring being searched for.|
 |**_replace_**|Required. Replacement substring.|
-|**_start_**|Optional. Position within  **_expression_** where substring search is to begin. If omitted, 1 is assumed.|
+|**_start_**|Optional. Start position for the substring of **_expression_** to be searched and returned. If omitted, 1 is assumed.|
 |**_count_**|Optional. Number of substring substitutions to perform. If omitted, the default value is -1, which means make all possible substitutions.|
 |**_compare_**|Optional. Numeric value indicating the kind of comparison to use when evaluating substrings. See Settings section for values.|
 


### PR DESCRIPTION
Extended the Description to make it clear, that the returned string can be a substring of the passed string expression. 
Modified the Part Description for the parameter start to reflect this.

Omitting these has caused a lot of confusion, as only the paragraph Remarks explains this.