### PR TITLE
update title

### DIFF
--- a/Language/Reference/User-Interface-Help/on-error-statement.md
+++ b/Language/Reference/User-Interface-Help/on-error-statement.md
@@ -1,5 +1,5 @@
 ---
-title: On Error statement
+title: On Error statement - VBA
 keywords: vblr6.chm1008985
 f1_keywords:
 - vblr6.chm1008985
@@ -7,8 +7,6 @@ ms.prod: office
 ms.assetid: 5f723da4-34bd-0a29-11b6-f6986d701570
 ms.date: 08/24/2018
 ---
-
-
 # On Error statement
 
 Enables an error-handling routine and specifies the location of the routine within a [procedure](../../Glossary/vbe-glossary.md#procedure); can also be used to disable an error-handling routine.


### PR DESCRIPTION
You should probably do the same change across your reference but doing for this one since we got a content feedback issue for this in our VB docs today (https://github.com/dotnet/docs/issues/7971). 

By looking at the search terms for https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/statements/on-error-statement, it seems a lot of folks are looking for the VBA statement instead but we rank higher. I've made a similar change to the Goto statement a few months back and now the VBA topic ranks higher when people type goto vba. 