### PR TITLE
Fix a typo: an one-off -> a one-off

### DIFF
--- a/api/Outlook.Rule.Enabled.md
+++ b/api/Outlook.Rule.Enabled.md
@@ -27,7 +27,7 @@ Returns or sets a  **Boolean** value that determines if the rule is to be applie
 
 Setting the  **Enabled** property of a rule does not guarantee that the rule will be enabled. The rule is enabled only after **[Rules.Save](Outlook.Rules.Save.md)** executes successfully.
 
-Using  **Rule.Enabled** and **Rules.Save** applies the rule consistently and persists the rules beyond the current session. Enabling a rule (that has been saved successfully) ensures that the rule will be applied. If it is a local client rule, the rule will be applied when Outlook is running, and if the rule is a server-based rule, it will be applied regardless of whether Outlook is running. If you do not enable the rule, then the rule is defined, but it will not be applied. However, you can use **[Rule.Execute](Outlook.Rule.Execute.md)** to apply a rule as an one-off operation regardless of whether the rule is enabled.
+Using  **Rule.Enabled** and **Rules.Save** applies the rule consistently and persists the rules beyond the current session. Enabling a rule (that has been saved successfully) ensures that the rule will be applied. If it is a local client rule, the rule will be applied when Outlook is running, and if the rule is a server-based rule, it will be applied regardless of whether Outlook is running. If you do not enable the rule, then the rule is defined, but it will not be applied. However, you can use **[Rule.Execute](Outlook.Rule.Execute.md)** to apply a rule as a one-off operation regardless of whether the rule is enabled.
 
 
 ## See also

--- a/api/Outlook.Rule.Execute.md
+++ b/api/Outlook.Rule.Execute.md
@@ -13,7 +13,7 @@ ms.date: 06/08/2017
 
 # Rule.Execute Method (Outlook)
 
-Applies a rule as an one-off operation.
+Applies a rule as a one-off operation.
 
 
 ## Syntax


### PR DESCRIPTION
Fix a typo: an one-off -> a one-off