### PR TITLE
Added missing spaces to print-statement

### DIFF
--- a/Language/Reference/User-Interface-Help/printstatement.md
+++ b/Language/Reference/User-Interface-Help/printstatement.md
@@ -26,14 +26,14 @@ The  **Print #** statement syntax has these parts:
 | _outputlist_|Optional. [Expression](../../Glossary/vbe-glossary.md#expression) or list of expressions to print.|
 
  **Settings**
-The  _outputlist_[argument](../../Glossary/vbe-glossary.md#argument) settings are:
+The  _outputlist_ [argument](../../Glossary/vbe-glossary.md#argument) settings are:
 [{ **Spc(**_n_**)** |**Tab** [ **(**_n_**)** ]}] [ _expression_ ] [ _charpos_ ]
 
 
 |**Setting**|**Description**|
 |:-----|:-----|
 |**Spc(**_n_**)**|Used to insert space characters in the output, where  _n_ is the number of space characters to insert.|
-|**Tab(**_n_**)**|Used to position the insertion point to an absolute column number, where  _n_ is the column number. Use **Tab** with no argument to position the insertion point at the beginning of the next[print zone](../../Glossary/vbe-glossary.md#print-zone).|
+|**Tab(**_n_**)**|Used to position the insertion point to an absolute column number, where  _n_ is the column number. Use **Tab** with no argument to position the insertion point at the beginning of the next [print zone](../../Glossary/vbe-glossary.md#print-zone).|
 | _expression_|[Numeric expressions](../../Glossary/vbe-glossary.md#numeric-expression) or [string expressions](../../Glossary/vbe-glossary.md#string-expression) to print.|
 | _charpos_|Specifies the insertion point for the next character. Use a semicolon to position the insertion point immediately after the last character displayed. Use  **Tab(**_n_**)** to position the insertion point to an absolute column number. Use **Tab** with no argument to position the insertion point at the beginning of the next print zone. If _charpos_ is omitted, the next character is printed on the next line.|
 


### PR DESCRIPTION
Fixed erroneously connected words, added a space before/after links.