### PR TITLE
Update Excel.Range.Find.md

### DIFF
--- a/api/Excel.Range.Find.md
+++ b/api/Excel.Range.Find.md
@@ -74,7 +74,7 @@ With Worksheets(1).Range("a1:a500")
         Do 
             c.Value = 5 
             Set c = .FindNext(c) 
-        Loop While Not c Is Nothing And c.Address <> firstAddress 
+        Loop While Not c Is Nothing
     End If 
 End With
 ```


### PR DESCRIPTION
In the first example a Run-time error '91' (Object variable or With block variable not set) error will occur once the last value has been replaced.  "c" will be Nothing as it can't find another value = 2, so "c.Address" will cause an error.
If, on the other hand, values aren't changed then "c" will never be nothing so you'd have to use " Loop While c.Address <> firstAddress".  This would be better explained with a second example?