### PR TITLE
Update like-operator.md

### DIFF
--- a/Language/Reference/User-Interface-Help/like-operator.md
+++ b/Language/Reference/User-Interface-Help/like-operator.md
@@ -31,12 +31,12 @@ The  **Like** operator syntax has these parts:
 ## Remarks
 
 If  _string_ matches _pattern_, _result_ is **True**; if there is no match, _result_ is **False**. If either _string_ or _pattern_ is [Null](../../Glossary/vbe-glossary.md#null),  _result_ is **Null**.  
-The behavior of the  **Like** operator depends on the **Option Compare** statement. The default[string-comparison](../../Glossary/vbe-glossary.md#string-comparison) method for each[module](../../Glossary/vbe-glossary.md#module) is **Option Compare** **Binary**.  
+The behavior of the  **Like** operator depends on the **Option Compare** statement. The default [string-comparison](../../Glossary/vbe-glossary.md#string-comparison) method for each [module](../../Glossary/vbe-glossary.md#module) is **Option Compare** **Binary**.  
 
 **Option Compare Binary** results in string comparisons based on a [sort order](../../Glossary/vbe-glossary.md#sort-order) derived from the internal binary representations of the characters. Sort order is determined by the code page. In the following example, a typical binary sort order is shown:  
 A < B < E < Z < a < b < e < z < À < Ê < Ø < à < ê < ø
  
-**Option Compare Text** results in string comparisons based on a case-insensitive, textual sort order determined by your system's[locale](../../Glossary/vbe-glossary.md#locale). When you sort the same characters using  **Option Compare Text**, the following text sort order is produced:  
+**Option Compare Text** results in string comparisons based on a case-insensitive, textual sort order determined by your system's [locale](../../Glossary/vbe-glossary.md#locale). When you sort the same characters using  **Option Compare Text**, the following text sort order is produced:  
 (A=a) < (À=à) < (B=b) < (E=e) < (Ê=ê) < (Z=z) < (Ø=ø)
 
 Built-in pattern matching provides a versatile tool for string comparisons. The pattern-matching features allow you to use wildcard characters, character lists, or character ranges, in any combination, to match strings. The following table shows the characters allowed in  _pattern_ and what they match:
@@ -50,7 +50,7 @@ Built-in pattern matching provides a versatile tool for string comparisons. The 
 |[ _charlist_ ]|Any single character in  _charlist_.|
 |[ **!**_charlist_ ]|Any single character not in  _charlist_.|
 
-A group of one or more characters ( _charlist_ ) enclosed in brackets (**[ ]**) can be used to match any single character in _string_ and can include almost any[character code](../../Glossary/vbe-glossary.md#character-code), including digits.
+A group of one or more characters ( _charlist_ ) enclosed in brackets (**[ ]**) can be used to match any single character in _string_ and can include almost any [character code](../../Glossary/vbe-glossary.md#character-code), including digits.
 
  **Note**  To match the special characters left bracket (**[**), question mark (**?**), number sign (**#**), and asterisk (**\***), enclose them in brackets. The right bracket (**]**) can't be used within a group to match itself, but it can be used outside a group as an individual character.
 
@@ -85,7 +85,7 @@ MyCheck = "aM5b" Like "a [L-P]#[!c-e]"    ' Returns True.
 MyCheck = "BAT123khg" Like "B?T*"    ' Returns True.
 MyCheck = "CAT123khg" Like "B?T*"    ' Returns False.
 MyCheck = "ab" Like "a*b"    ' Returns True.
-MyCheck = "a*b" Like "a [*]b"    ' Returns True.
+MyCheck = "a*b" Like "a [*]b"    ' Returns False.
 MyCheck = "axxxxxb" Like "a [*]b"    ' Returns False.
 MyCheck = "a [xyz" Like "a [[]*"    ' Returns True.
 MyCheck = "a [xyz" Like "a [*"    ' Throws Error 93 (invalid pattern string).


### PR DESCRIPTION
Added a space: default [string-comparison]
Added a space: each [module]
Added a space: system's [locale]
Added a space: any [character code]
MyCheck = "a*b" Like "a [*]b"    ' Returns True. is incorrect. The comparison actually returns FALSE.