### PR TITLE
Update private-statement.md

### DIFF
--- a/Language/Reference/User-Interface-Help/private-statement.md
+++ b/Language/Reference/User-Interface-Help/private-statement.md
@@ -60,7 +60,7 @@ When variables are initialized, a numeric variable is initialized to 0, a variab
 
 
 > [!NOTE] 
-> When you use the **Private** statement in a procedure, you generally put the **Private** statement at the beginning of the procedure.
+> The **Private** statement cannot be used inside a procedure; use the **Dim** statement to declare local variables.
 
 
 ## Example


### PR DESCRIPTION
The `Private` keyword is flat-out illegal inside a procedure scope. Also, the remark about having a wall-of-declarations at the start of a procedure, is actively harmful - variables should be declared close to where they're used, like in any other language; [Rubberduck](https://github.com/rubberduck-vba/Rubberduck) OSS VBIDE add-in has a refactoring feature to *move variable declaration closer to usage*.
`Dim` statements aren't executable, so their position in a procedure is irrelevant, so long as they appear before they are used.
Since this isn't a page about `Dim` or best practices in general, I held back from adding a note to that effect, but for correctness' sake I _had_ to remove the bit about locals being "generally declared near the top of a procedure".