### PR TITLE
Update queryclose-event.md

### DIFF
--- a/Language/Reference/User-Interface-Help/queryclose-event.md
+++ b/Language/Reference/User-Interface-Help/queryclose-event.md
@@ -52,7 +52,7 @@ The following code forces the user to click the **UserForm** client area to clos
 
 ```vb
 Private Sub UserForm_Activate()
-    UserForm1.Caption = "You must Click me to kill me!"
+    Me.Caption = "You must Click me to kill me!"
 End Sub
 
 Private Sub UserForm_Click()
@@ -62,7 +62,7 @@ End Sub
 Private Sub UserForm_QueryClose(Cancel As Integer, CloseMode As Integer)
     'Prevent user from closing with the Close box in the title bar.
     If CloseMode <> 1 Then Cancel = 1
-    UserForm1.Caption = "The Close box won't work! Click me!"
+    Me.Caption = "The Close box won't work! Click me!"
 End Sub
 ```
 


### PR DESCRIPTION
Replaced references to form's *default instance* with the `Me` identifier, which refers to the *current* instance. UserForm code written against the default instance typically breaks when a `New` instance of the form is displayed. Default instances in general should never be stateful - *especially* for userforms. A better practice would be to implement a *Model-View-Presenter* pattern (an OOP approach), for much more robust code. My article [UserForm1.Show](https://rubberduckvba.wordpress.com/2017/10/25/userform1-show/) goes in deeper details.