### PR TITLE
fix: access/Concepts/Miscellaneous/circular-reference-caused-by-alias-name-in-query-definition-s-select-listerror-3.md

### DIFF
--- a/access/Concepts/Miscellaneous/circular-reference-caused-by-alias-name-in-query-definition-s-select-listerror-3.md
+++ b/access/Concepts/Miscellaneous/circular-reference-caused-by-alias-name-in-query-definition-s-select-listerror-3.md
@@ -30,8 +30,8 @@ FROM MyTable;
 
 
 
-```c#
-SELECT week1 + week2 as hours, hours + overtime as gross, gross + ytdpay as week1FROM EmployeePay
+```sql
+SELECT week1 + week2 as hours, hours + overtime as gross, gross + ytdpay as week1 FROM EmployeePay
 
 ```
 


### PR DESCRIPTION

Update code fence language and add space before FROM keyword