### PR TITLE
typos: api folder

### DIFF
--- a/Language/Reference/User-Interface-Help/hex-function.md
+++ b/Language/Reference/User-Interface-Help/hex-function.md
@@ -33,7 +33,7 @@ The required _number_ [argument](../../Glossary/vbe-glossary.md#argument) is any
 
 If _number_ is not a whole number, it is rounded to the nearest whole number before being evaluated.
 
-For the opposite of **Hex**, precede a hexidecimal value with **&H**. For example, `Hex(255)` returns the string FF and `&HFF` returns the number 255.
+For the opposite of **Hex**, precede a hexadecimal value with **&H**. For example, `Hex(255)` returns the string FF and `&HFF` returns the number 255.
 
 
 ## Example

--- a/api/Access.AcColorIndex.md
+++ b/api/Access.AcColorIndex.md
@@ -25,7 +25,7 @@ Specifies the color to apply.
 |**acColorIndexBlue**|12|Blue color.|
 |**acColorIndexBrightGreen**|10|Bright green color.|
 |**acColorIndexDarkBlue**|4|Dark blue color.|
-|**acColorIndexFuschia**|13|Fuchsia color.|
+|**acColorIndexFuchsia**|13|Fuchsia color.|
 |**acColorIndexGray**|7|Gray color.|
 |**acColorIndexGreen**|2|Green color.|
 |**acColorIndexMaroon**|1|Maroon color.|

--- a/api/Excel.Application.CalculationInterruptKey.md
+++ b/api/Excel.Application.CalculationInterruptKey.md
@@ -35,11 +35,11 @@ Sub CheckInterruptKey()
  ' Determine the calculation interrupt key and notify the user. 
  Select Case Application.CalculationInterruptKey 
  Case xlAnyKey 
- MsgBox "The calcuation interrupt key is set to any key." 
+ MsgBox "The calculation interrupt key is set to any key." 
  Case xlEscKey 
- MsgBox "The calcuation interrupt key is set to 'Escape'" 
+ MsgBox "The calculation interrupt key is set to 'Escape'" 
  Case xlNoKey 
- MsgBox "The calcuation interrupt key is set to no key." 
+ MsgBox "The calculation interrupt key is set to no key." 
  End Select 
  
 End Sub

--- a/api/Excel.Application.ConvertFormula.md
+++ b/api/Excel.Application.ConvertFormula.md
@@ -30,7 +30,7 @@ _expression_ A variable that represents an [Application](Excel.Application-graph
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _Formula_|Required| **Variant**|A string that containis the formula you want to convert. This must be a valid formula, and it must begin with an equal sign.|
+| _Formula_|Required| **Variant**|A string that contains the formula you want to convert. This must be a valid formula, and it must begin with an equal sign.|
 | _FromReferenceStyle_|Required| **[xlReferenceStyle](Excel.XlReferenceStyle.md)**|The reference style of the formula.|
 | _ToReferenceStyle_|Optional| **Variant**|A constant of  **xlReferenceStyle** specifying the reference style you want returned. If this argument is omitted, the reference style isn't changed; the formula stays in the style specified by _FromReferenceStyle_.|
 | _ToAbsolute_|Optional| **Variant**|A constant of  **[xlReferenceType](Excel.XlReferenceType.md)** which specifies the converted reference type. If this argument is omitted, the reference type isn't changed.|

--- a/api/Excel.Application.DeferAsyncQueries.md
+++ b/api/Excel.Application.DeferAsyncQueries.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Application.DeferAsyncQueries property (Excel)
 
-Gets or sets whether asychronous queries to OLAP data sources are executed when a worksheet is calculated by VBA code. Read/write  **Boolean**.
+Gets or sets whether asynchronous queries to OLAP data sources are executed when a worksheet is calculated by VBA code. Read/write  **Boolean**.
 
 
 ## Syntax

--- a/api/Excel.Application.SheetPivotTableAfterValueChange.md
+++ b/api/Excel.Application.SheetPivotTableAfterValueChange.md
@@ -32,7 +32,7 @@ _expression_ A variable that represents a '[Application](Excel.Application(objec
 |:-----|:-----|:-----|:-----|
 | _Sh_|Required| **Object**|The worksheet that contains the PivotTable|
 | _TargetPivotTable_|Required| **[PivotTable](Excel.PivotTable.md)**|The PivotTable that contains the edited or recalculated cells.|
-| _TargetRange_|Required| **[Range](Excel.Range(object).md)**|The range that contains all the edited or recalcuated cells.|
+| _TargetRange_|Required| **[Range](Excel.Range(object).md)**|The range that contains all the edited or recalculated cells.|
 
 ## Return value
 

--- a/api/Excel.CellFormat.AddIndent.md
+++ b/api/Excel.CellFormat.AddIndent.md
@@ -26,7 +26,7 @@ _expression_ A variable that represents a [CellFormat](Excel.CellFormat.md) obje
 
 ## Remarks
 
-Set the value of this property to  **True** to autmatically indent text when the text alignment in the cell is set, either horizontally or vertically, to equal distribution.
+Set the value of this property to  **True** to automatically indent text when the text alignment in the cell is set, either horizontally or vertically, to equal distribution.
 
 To set text alignment to equal distribution, you can set the  **[VerticalAlignment](Excel.Range.VerticalAlignment.md)** property to **xlVAlignDistributed** when the value of the **[Orientation](Excel.Range.Orientation.md)** property is **xlVertical** , and you can set the **[HorizontalAlignment](Excel.Range.HorizontalAlignment.md)** property to **xlHAlignDistributed** when the value of the **Orientation** property is **xlHorizontal**.
 

--- a/api/Excel.Chart.MailEnvelope.md
+++ b/api/Excel.Chart.MailEnvelope.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Chart.MailEnvelope property (Excel)
 
-Rrepresents an email header for a document.
+Represents an email header for a document.
 
 
 ## Syntax

--- a/api/Excel.ConditionValue.md
+++ b/api/Excel.ConditionValue.md
@@ -26,7 +26,7 @@ You can change the type of evaluation from the default setting (lowest value for
 
 ## Example
 
-The following example creates a range of data and then applies a data bar to the range. You will notice that because there is an extremely low and high value in the range, the middle values have data bars that are of similiar length. To disambiguate the middle values, the sample code uses the  **ConditionValue** object to change how the thresholds are evaluated to percentiles.
+The following example creates a range of data and then applies a data bar to the range. You will notice that because there is an extremely low and high value in the range, the middle values have data bars that are of similar length. To disambiguate the middle values, the sample code uses the  **ConditionValue** object to change how the thresholds are evaluated to percentiles.
 
 
 ```vb

--- a/api/Excel.Connections.Add.md
+++ b/api/Excel.Connections.Add.md
@@ -14,7 +14,7 @@ localization_priority: Priority
 
 # Connections.Add method (Excel)
 
-Adds a new connction to the workbook.
+Adds a new connection to the workbook.
 
 
 ## Syntax

--- a/api/Excel.ConnectorFormat.md
+++ b/api/Excel.ConnectorFormat.md
@@ -77,7 +77,7 @@ Set myDocument = Worksheets(1)
 Set s = myDocument.Shapes 
 Set firstRect = s.AddShape(msoShapeRectangle, 100, 50, 200, 100) 
 Set secondRect = s.AddShape(msoShapeRectangle, 300, 300, 200, 100) 
-Setc c = s.AddConnector(msoConnectorCurve, 0, 0, 0, 0) 
+Set c = s.AddConnector(msoConnectorCurve, 0, 0, 0, 0) 
 With c.ConnectorFormat 
  .BeginConnect ConnectedShape:=firstRect, ConnectionSite:=1 
  .EndConnect ConnectedShape:=secondRect, ConnectionSite:=1 

--- a/api/Excel.CubeField.EnableMultiplePageItems.md
+++ b/api/Excel.CubeField.EnableMultiplePageItems.md
@@ -38,9 +38,9 @@ Sub UseMultiplePageItems()
  Set pvtTable = ActiveSheet.PivotTables(1) 
  Set cbeField = pvtTable.CubeFields("[Country]") 
  
- ' Determine setting for mulitple page items. 
+ ' Determine setting for multiple page items. 
  If cbeField.EnableMultiplePageItems = False Then 
- MsgBox "Mulitple page items cannot be selected." 
+ MsgBox "Multiple page items cannot be selected." 
  Else 
  MsgBox "Multiple page items can be selected." 
  End If 

--- a/api/Excel.Databar.md
+++ b/api/Excel.Databar.md
@@ -21,14 +21,14 @@ Represents a data bar conditional formating rule. Applying a data bar to a range
 
 All conditional formatting objects are contained within a  **[FormatConditions](Excel.FormatConditions.md)** collection object, which is a child of a **[Range](Excel.Range(object).md)** collection. You can create a data bar formatting rule by using either the **[Add](Excel.FormatConditions.Add.md)** or **[AddDatabar](Excel.FormatConditions.AddDatabar.md)** methods of the **FormatConditions** collection.
 
-You use the  **[MinPoint](Excel.Databar.MinPoint.md)** and **[MaxPoint](Excel.Databar.MaxPoint.md)** properties of the **Databar** object to set the values of the shortest bar and longest bar of a range of data. These properites return a **[ConditionValue](Excel.ConditionValue.md)** object, with which you can specify how the thresholds are evaluated.
+You use the  **[MinPoint](Excel.Databar.MinPoint.md)** and **[MaxPoint](Excel.Databar.MaxPoint.md)** properties of the **Databar** object to set the values of the shortest bar and longest bar of a range of data. These properties return a **[ConditionValue](Excel.ConditionValue.md)** object, with which you can specify how the thresholds are evaluated.
 
 The  **Databar** object also provides properties that enable you to specify an axis line that is displayed when negative values are present, and to specify the color and formatting of data bars.
 
 
 ## Example
 
-The following example creates a range of data and then applies a data bar to the range. You will notice that because there is an extremely low and high value in the range, the middle values have data bars that are of similiar length. To disambiguate the middle values, the sample code uses the  **ConditionValue** object to change how the thresholds are evaluated to percentiles.
+The following example creates a range of data and then applies a data bar to the range. You will notice that because there is an extremely low and high value in the range, the middle values have data bars that are of similar length. To disambiguate the middle values, the sample code uses the  **ConditionValue** object to change how the thresholds are evaluated to percentiles.
 
 
 ```vb

--- a/api/Excel.DefaultWebOptions.FolderSuffix.md
+++ b/api/Excel.DefaultWebOptions.FolderSuffix.md
@@ -73,7 +73,7 @@ The following table lists each language version of Office, and gives its corresp
 |Swedish|1053|-filer|
 |Thai|1054|.files|
 |Turkish|1055|_dosyalar|
-|Ukranian|1058|.files|
+|Ukrainian|1058|.files|
 |Vietnamese|1066|.files|
 
 ## See also

--- a/api/Excel.FileExportConverter.md
+++ b/api/Excel.FileExportConverter.md
@@ -37,7 +37,7 @@ The index number represents the position of the file converter in the  **FileExp
 
 
 ```vb
-MsgBox FileExportConvters(1).Description
+MsgBox FileExportConverters(1).Description
 ```
 
 

--- a/api/Excel.FileExportConverters.md
+++ b/api/Excel.FileExportConverters.md
@@ -39,7 +39,7 @@ The index number represents the position of the file converter in the  **FileExp
 
 
 ```vb
-MsgBox FileExportConvters(1).Description
+MsgBox FileExportConverters(1).Description
 ```
 
 

--- a/api/Excel.FillFormat.PictureEffects.md
+++ b/api/Excel.FillFormat.PictureEffects.md
@@ -18,7 +18,7 @@ Returns an object that represents the picture or texture fill for the specified 
 
 _expression_. `PictureEffects`
 
-_expression_ A variable that repressents a '[FillFormat](Excel.FillFormat.md)' object.
+_expression_ A variable that represents a '[FillFormat](Excel.FillFormat.md)' object.
 
 
 ## Return value
@@ -28,7 +28,7 @@ _expression_ A variable that repressents a '[FillFormat](Excel.FillFormat.md)' o
 
 ## Remarks
 
-A picture or texture fill can be specified in the formatting for various elements (shapes) in a chart. For example, you can use the  **Format Data Series** dialog box to format the columns in a **Column** chart to a picture or texture fill. In this case, the **PictureEffects** property returns a **PictureEffects** collection that corresponds to the settings associated with the **Picture or texture fili** option in the **Fill** category of the **Format Data Series** dialog box.
+A picture or texture fill can be specified in the formatting for various elements (shapes) in a chart. For example, you can use the  **Format Data Series** dialog box to format the columns in a **Column** chart to a picture or texture fill. In this case, the **PictureEffects** property returns a **PictureEffects** collection that corresponds to the settings associated with the **Picture or texture fill** option in the **Fill** category of the **Format Data Series** dialog box.
 
 
 ## See also

--- a/api/Excel.Font.Background.md
+++ b/api/Excel.Font.Background.md
@@ -33,7 +33,7 @@ _expression_ A variable that represents a [Font](Excel.Font-graph-property.md) o
 |**xlBackground can be one of the following constants**|**Description of text background**|
 |:-----|:-----|
 | **xlBackgroundAutomatic**|Font background will automatically change the background area around the text to a color that best displays the chart text on the color applied to elements under the text|
-| **xlBackgroundOpaque**|Font background will set the font bacground to black if the text color and fill color underneath the text are very close or the same color, such that the text would not appear|
+| **xlBackgroundOpaque**|Font background will set the font background to black if the text color and fill color underneath the text are very close or the same color, such that the text would not appear|
 | **xlBackgroundTransparent**|Font background is set to transparent so that text background does not change if the text color is close to the color underneath the text|
 
 ## Example

--- a/api/Excel.FormatCondition.md
+++ b/api/Excel.FormatCondition.md
@@ -21,16 +21,16 @@ Represents a conditional format.
 
  The **FormatCondition** object is a member of the **[FormatConditions](Excel.FormatConditions.md)** collection. The **FormatConditions** collection can now contain more than three conditional formats for a given range.
 
-Use the  **[Add](Excel.FormatConditions.Add.md)** method to create a new conditional format. If a range has mulitple formats, you can use the **[Modify](Excel.FormatCondition.Modify.md)** method to change one of the formats, or you can use the **[Delete](Excel.FormatCondition.Delete.md)** method to delete a format and then use the **Add** method to create a new format.
+Use the  **[Add](Excel.FormatConditions.Add.md)** method to create a new conditional format. If a range has multiple formats, you can use the **[Modify](Excel.FormatCondition.Modify.md)** method to change one of the formats, or you can use the **[Delete](Excel.FormatCondition.Delete.md)** method to delete a format and then use the **Add** method to create a new format.
 
-Use the  **[Font](Excel.FormatCondition.Font.md)**, **[Borders](Excel.FormatCondition.Borders.md)**, and **[Interior](Excel.FormatCondition.Interior.md)** properties of the **FormatCondition** object to control the appearance of formatted cells. Some properties of these objects aren?t supported by the conditional format object model. Some of the properties that can be used with conditional formatting are listed in the following table.
+Use the  **[Font](Excel.FormatCondition.Font.md)**, **[Borders](Excel.FormatCondition.Borders.md)**, and **[Interior](Excel.FormatCondition.Interior.md)** properties of the **FormatCondition** object to control the appearance of formatted cells. Some properties of these objects aren't supported by the conditional format object model. Some of the properties that can be used with conditional formatting are listed in the following table.
 
 
 
 |**Object**|**Properties**|
 |:-----|:-----|
 |**[Font](Excel.Font(object).md)**|**Bold** **Color** **ColorIndex** **FontStyle** **Italic** **Strikethrough** **Underline** The accounting underline styles cannot be used.|
-|**[Border](Excel.Border(object).md)**|**Bottom** **Color** **Left** **Right** **Style** The following border styles can be used (all others aren?t supported): **xlNone**, **xlSolid**, **xlDash**, **xlDot**, **xlDashDot**, **xlDashDotDot**, **xlGray50**, **xlGray75**, and **xlGray25**. **Top** **Weight** The following border weights can be used (all others aren?t supported): **xlWeightHairline** and **xlWeightThin**.|
+|**[Border](Excel.Border(object).md)**|**Bottom** **Color** **Left** **Right** **Style** The following border styles can be used (all others aren't supported): **xlNone**, **xlSolid**, **xlDash**, **xlDot**, **xlDashDot**, **xlDashDotDot**, **xlGray50**, **xlGray75**, and **xlGray25**. **Top** **Weight** The following border weights can be used (all others aren't supported): **xlWeightHairline** and **xlWeightThin**.|
 |**[Interior](Excel.Interior(object).md)**|**Color** **ColorIndex** **Pattern** **PatternColorIndex**|
 
 ## Example

--- a/api/Excel.Graphic.CropRight.md
+++ b/api/Excel.Graphic.CropRight.md
@@ -39,7 +39,7 @@ Set myDocument = Worksheets(1)
 myDocument.Shapes(3).PictureFormat.CropRight = 20
 ```
 
-Using this example, you can specify the percentage you want to cropp off the right side of the selected shape, regardless of whether the shape has been scaled. For the example to work, the selected shape must be either a picture or an OLE object.
+Using this example, you can specify the percentage you want to crop off the right side of the selected shape, regardless of whether the shape has been scaled. For the example to work, the selected shape must be either a picture or an OLE object.
 
 
 

--- a/api/Excel.Hyperlink.Follow.md
+++ b/api/Excel.Hyperlink.Follow.md
@@ -34,7 +34,7 @@ _expression_ A variable that represents a [Hyperlink](Excel.Hyperlink.md) object
 | _AddHistory_|Optional| **Variant**|Not used. Reserved for future use.|
 | _ExtraInfo_|Optional| **Variant**|A  **String** or byte array that specifies additional information for HTTP to use to resolve the hyperlink. For example, you can use _ExtraInfo_ to specify the coordinates of an image map, the contents of a form, or a FAT file name.|
 | _Method_|Optional| **Variant**|Specifies the way  _ExtraInfo_ is attached. Can be one of the **[MsoExtraInfoMethod](Office.MsoExtraInfoMethod.md)** constants.|
-| _HeaderInfo_|Optional| **Variant**|A  **String** that specifies header information for the HTTP request. The defaut value is an empty string.|
+| _HeaderInfo_|Optional| **Variant**|A  **String** that specifies header information for the HTTP request. The default value is an empty string.|
 
 ## Example
 

--- a/api/Excel.IconCriterion.Operator.md
+++ b/api/Excel.IconCriterion.Operator.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # IconCriterion.Operator property (Excel)
 
-Returns or sets one of the constants of the  **[xlFormatConditionOperator](Excel.XlFormatConditionOperator.md)** enumeration, which specifes if the threshold is "greater than" or "greater than or equal to" the threshold value.
+Returns or sets one of the constants of the  **[xlFormatConditionOperator](Excel.XlFormatConditionOperator.md)** enumeration, which specifies if the threshold is "greater than" or "greater than or equal to" the threshold value.
 
 
 ## Syntax

--- a/api/Excel.OLEDBConnection.md
+++ b/api/Excel.OLEDBConnection.md
@@ -19,7 +19,7 @@ Represents the OLE DB connection.
 
 ## Remarks
 
-An OLE DB connection can be stored in an Excel workbook. When Micrososft Excel opens the workbook, Excel creates an in-memory copy of the OLE DB connection known as the  **OLEDBConnection** object.
+An OLE DB connection can be stored in an Excel workbook. When Microsoft Excel opens the workbook, Excel creates an in-memory copy of the OLE DB connection known as the  **OLEDBConnection** object.
 
 An  **OLEDBConnection** object contains information related to the connection, such as the name of the server to connect to and the name of the objects to be opened on that server. Optionally, the **OLEDBConnection** object may also include authentication credential information, or a command that is to be passed to the server and executed (for example, a `SELECT` statement to be executed by SQL Server).
 

--- a/api/Excel.PageSetup.PrintErrors.md
+++ b/api/Excel.PageSetup.PrintErrors.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # PageSetup.PrintErrors property (Excel)
 
-Sets or returns an  **[xlPrintErrors](Excel.XlPrintErrors.md)** contstant specifying the type of print error displayed. This feature allows users to suppress the display of error values when printing a worksheet. Read/write .
+Sets or returns an  **[xlPrintErrors](Excel.XlPrintErrors.md)** constant specifying the type of print error displayed. This feature allows users to suppress the display of error values when printing a worksheet. Read/write .
 
 
 ## Syntax

--- a/api/Excel.PictureFormat.CropRight.md
+++ b/api/Excel.PictureFormat.CropRight.md
@@ -39,7 +39,7 @@ Set myDocument = Worksheets(1)
 myDocument.Shapes(3).PictureFormat.CropRight = 20
 ```
 
-Using this example, you can specify the percentage you want to cropp off the right side of the selected shape, regardless of whether the shape has been scaled. For the example to work, the selected shape must be either a picture or an OLE object.
+Using this example, you can specify the percentage you want to crop off the right side of the selected shape, regardless of whether the shape has been scaled. For the example to work, the selected shape must be either a picture or an OLE object.
 
 
 

--- a/api/Excel.PictureFormat.IncrementContrast.md
+++ b/api/Excel.PictureFormat.IncrementContrast.md
@@ -39,7 +39,7 @@ You cannot adjust the contrast of a picture past the upper or lower limit for th
 
 ## Example
 
-This example increases the contrast for all pictures on  `myDocument` that aren?t already set to maximum contrast.
+This example increases the contrast for all pictures on  `myDocument` that aren't already set to maximum contrast.
 
 
 ```vb

--- a/api/Excel.PivotField.AllItemsVisible.md
+++ b/api/Excel.PivotField.AllItemsVisible.md
@@ -34,7 +34,7 @@ For PivotTables, this property is available for the  **PivotField** object.
 
 The default value is  **True**. This property is automatically set to **True** when no manual filtering is applied (independent of whether the **IncludeNewItemsInFilter** property is **True** or **False**). It is automatically set to **False** when any manual filtering is applied (independent of whether the **IncludeNewItemsInFilter** property is **True** or **False**).
 
-This property directly reflects the state of the  **Select All** check box in the filter drop-down lislt for the PivotField or CubeField.
+This property directly reflects the state of the  **Select All** check box in the filter drop-down list for the PivotField or CubeField.
 
 
 ## See also

--- a/api/Excel.PivotField.StandardFormula.md
+++ b/api/Excel.PivotField.StandardFormula.md
@@ -37,7 +37,7 @@ This example adds 10 to the Decimals field and displays it as a calculated item 
 
 
 ```vb
-Sub UseStandardFomula() 
+Sub UseStandardFormula() 
  
  Dim pvtTable As PivotTable 
  Set pvtTable = ActiveSheet.PivotTables(1) 

--- a/api/Excel.PivotFormula.StandardFormula.md
+++ b/api/Excel.PivotFormula.StandardFormula.md
@@ -37,7 +37,7 @@ This example adds 10 to the Decimals field and displays it as a calculated item 
 
 
 ```vb
-Sub UseStandardFomula() 
+Sub UseStandardFormula() 
  
  Dim pvtTable As PivotTable 
  Set pvtTable = ActiveSheet.PivotTables(1) 

--- a/api/Excel.PivotItem.StandardFormula.md
+++ b/api/Excel.PivotItem.StandardFormula.md
@@ -37,7 +37,7 @@ This example adds 10 to the Decimals field and displays it as a calculated item 
 
 
 ```vb
-Sub UseStandardFomula() 
+Sub UseStandardFormula() 
  
  Dim pvtTable As PivotTable 
  Set pvtTable = ActiveSheet.PivotTables(1) 

--- a/api/Excel.PivotTable.ChangeConnection.md
+++ b/api/Excel.PivotTable.ChangeConnection.md
@@ -30,7 +30,7 @@ _expression_ A variable that represents a [PivotTable](Excel.PivotTable.md) obje
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _conn_|Required| **WorkbookConnection**|A  **[WorkbookConnection](Excel.WorkbookConnection.md)** object that represents the new conneciton for the PivotTable.|
+| _conn_|Required| **WorkbookConnection**|A  **[WorkbookConnection](Excel.WorkbookConnection.md)** object that represents the new connection for the PivotTable.|
 
 ## Remarks
 

--- a/api/Excel.PivotTable.PivotTableWizard.md
+++ b/api/Excel.PivotTable.PivotTableWizard.md
@@ -44,7 +44,7 @@ _expression_ A variable that represents a [PivotTable](Excel.PivotTable.md) obje
 | _OptimizeCache_|Optional| **Variant**| **True** to optimize the PivotTable cache when it's constructed. The default value is **False**.|
 | _PageFieldOrder_|Optional| **Variant**|The order in which page fields are added to the PivotTable report?s layout. Can be one of the following  **xlOrder** constants: **xlDownThenOver** or **xlOverThenDown**. The default value is **xlDownThenOver**.|
 | _PageFieldWrapCount_|Optional| **Variant**|The number of page fields in each column or row in the PivotTable report. The default value is 0 (zero).|
-| _ReadData_|Optional| **Variant**| **True** to create a PivotTable cache that contains all records from the external database; this cache can be very large. If _ReadData_ is **False** , you can set some of the fields asserver-based page fields before the data is actually read.|
+| _ReadData_|Optional| **Variant**| **True** to create a PivotTable cache that contains all records from the external database; this cache can be very large. If _ReadData_ is **False** , you can set some of the fields as server-based page fields before the data is actually read.|
 | _Connection_|Optional| **Variant**|A string that contains ODBC settings that allow Excel to connect to an ODBC data source. The connection string has the form "ODBC;<connection string>". This argument overrides any previous setting for the  **[PivotCache](Excel.PivotCache.md)** object?s **[Connection](Excel.PivotCache.Connection.md)** property.|
 
 ## See also

--- a/api/Excel.PivotTable.ShowTableStyleColumnHeaders.md
+++ b/api/Excel.PivotTable.ShowTableStyleColumnHeaders.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # PivotTable.ShowTableStyleColumnHeaders property (Excel)
 
-The  **ShowTableStyleColumnHeaders** property is set to **True** if the coulmn headers should be displayed in the PivotTable. Read/write **Boolean**.
+The  **ShowTableStyleColumnHeaders** property is set to **True** if the column headers should be displayed in the PivotTable. Read/write **Boolean**.
 
 
 ## Syntax

--- a/api/Excel.QueryTable.TextFileParseType.md
+++ b/api/Excel.QueryTable.TextFileParseType.md
@@ -30,7 +30,7 @@ _expression_ A variable that represents a [QueryTable](Excel.QueryTable.md) obje
 
 | **xlTextParsingType** can be one of these **xlTextParsingType** constants.|
 | **xlFixedWidth**. Indicates that the data in the file is arranged in columns of fixed widths.|
-| **xlDelimited**_default_ . Iindicates the file is delimited by delimiter characters|
+| **xlDelimited**_default_ . Indicates the file is delimited by delimiter characters|
 
 Use this property only when your query table is based on data from a text file (with the  **[QueryType](Excel.QueryTable.QueryType.md)** property set to **xlTextImport**).
 

--- a/api/Excel.Range.AddIndent.md
+++ b/api/Excel.Range.AddIndent.md
@@ -26,7 +26,7 @@ _expression_ A variable that represents a [Range](excel.range-graph-property.md)
 
 ## Remarks
 
-Set the value of this property to  **True** to autmatically indent text when the text alignment in the cell is set, either horizontally or vertically, to equal distribution.
+Set the value of this property to  **True** to automatically indent text when the text alignment in the cell is set, either horizontally or vertically, to equal distribution.
 
 To set text alignment to equal distribution, you can set the  **[VerticalAlignment](Excel.Range.VerticalAlignment.md)** property to **xlVAlignDistributed** when the value of the **[Orientation](Excel.Range.Orientation.md)** property is **xlVertical** , and you can set the **[HorizontalAlignment](Excel.Range.HorizontalAlignment.md)** property to **xlHAlignDistributed** when the value of the **Orientation** property is **xlHorizontal**.
 

--- a/api/Excel.Shape.Vertices.md
+++ b/api/Excel.Shape.Vertices.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Shape.Vertices property (Excel)
 
-Returns the coordinates of the specified freeform drawing's vertices (and control points for B?zier curves) as a series of coordinate pairs. You can use the array returned by this property as an argument to the  **[AddCurve](Excel.Shapes.AddCurve.md)** method or **[AddPolyLine](Excel.Shapes.AddPolyline.md)** method. Read-only **Variant**.
+Returns the coordinates of the specified freeform drawing's vertices (and control points for Bézier curves) as a series of coordinate pairs. You can use the array returned by this property as an argument to the  **[AddCurve](Excel.Shapes.AddCurve.md)** method or **[AddPolyLine](Excel.Shapes.AddPolyline.md)** method. Read-only **Variant**.
 
 
 ## Syntax

--- a/api/Excel.ShapeRange.Vertices.md
+++ b/api/Excel.ShapeRange.Vertices.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # ShapeRange.Vertices property (Excel)
 
-Returns the coordinates of the specified freeform drawing's vertices (and control points for B?zier curves) as a series of coordinate pairs. You can use the array returned by this property as an argument to the  **[AddCurve](Excel.Shapes.AddCurve.md)** method or **[AddPolyLine](Excel.Shapes.AddPolyline.md)** method. Read-only **Variant**.
+Returns the coordinates of the specified freeform drawing's vertices (and control points for Bézier curves) as a series of coordinate pairs. You can use the array returned by this property as an argument to the  **[AddCurve](Excel.Shapes.AddCurve.md)** method or **[AddPolyLine](Excel.Shapes.AddPolyline.md)** method. Read-only **Variant**.
 
 
 ## Syntax

--- a/api/Excel.Shapes.AddConnector.md
+++ b/api/Excel.Shapes.AddConnector.md
@@ -34,7 +34,7 @@ _expression_ A variable that represents a [Shapes](./Excel.Shapes.md) object.
 | _BeginX_|Required| **Single**|The horizontal position (in points) of the connector's starting point relative to the upper-left corner of the document.|
 | _BeginY_|Required| **Single**|The vertical position (in points) of the connector's starting point relative to the upper-left corner of the document.|
 | _EndX_|Required| **Single**|The horizontal position (in points) of the connector's end point relative to the upper-left corner of the document.|
-| _EndY_|Required| **Single**|The veritcal position (in points) of the connector's end point relative to the upper-left corner of the document.|
+| _EndY_|Required| **Single**|The vertical position (in points) of the connector's end point relative to the upper-left corner of the document.|
 
 ## Return value
 

--- a/api/Excel.Shapes.AddCurve.md
+++ b/api/Excel.Shapes.AddCurve.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Shapes.AddCurve method (Excel)
 
-Returns a  **[Shape](Excel.Shape.md)** object that represents a B?zier curve in a worksheet.
+Returns a  **[Shape](Excel.Shape.md)** object that represents a Bézier curve in a worksheet.
 
 
 ## Syntax
@@ -30,7 +30,7 @@ _expression_ A variable that represents a [Shapes](./Excel.Shapes.md) object.
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _SafeArrayOfPoints_|Required| **Variant**|An array of coordinate pairs that specifies the vertices and control points of the curve. The first point you specify is the starting vertex, and the next two points are control points for the first B?zier segment. Then, for each additional segment of the curve, you specify a vertex and two control points. The last point you specify is the ending vertex for the curve. Note that you must always specify 3n + 1 points, where n is the number of segments in the curve.|
+| _SafeArrayOfPoints_|Required| **Variant**|An array of coordinate pairs that specifies the vertices and control points of the curve. The first point you specify is the starting vertex, and the next two points are control points for the first Bézier segment. Then, for each additional segment of the curve, you specify a vertex and two control points. The last point you specify is the ending vertex for the curve. Note that you must always specify 3n + 1 points, where n is the number of segments in the curve.|
 
 ## Return value
 
@@ -39,7 +39,7 @@ Shape
 
 ## Example
 
-The following example adds a two-segment B?zier curve to  `myDocument`.
+The following example adds a two-segment Bézier curve to  `myDocument`.
 
 
 ```vb

--- a/api/Excel.Sort.md
+++ b/api/Excel.Sort.md
@@ -19,7 +19,7 @@ Represents a sort of a range of data.
 
 ## Example
 
-The following proceedure builds and sorts data in a range in the active worksheet.
+The following procedure builds and sorts data in a range in the active worksheet.
 
 
 ```vb

--- a/api/Excel.SpellingOptions.md
+++ b/api/Excel.SpellingOptions.md
@@ -57,7 +57,7 @@ The following example uses the  **[IgnoreCaps](Excel.SpellingOptions.IgnoreCaps.
 ```vb
 Sub IgnoreAllCAPS() 
  
- ' Place mispelled versions of the same word in all caps and mixed case. 
+ ' Place misspelled versions of the same word in all caps and mixed case. 
  Range("A1").Formula = "Testt" 
  Range("A2").Formula = "TESTT" 
  

--- a/api/Excel.Style.AddIndent.md
+++ b/api/Excel.Style.AddIndent.md
@@ -26,7 +26,7 @@ _expression_ A variable that represents a [Style](./Excel.Style.md) object.
 
 ## Remarks
 
-Set the value of this property to  **True** to autmatically indent text when the text alignment in the cell is set, either horizontally or vertically, to equal distribution.
+Set the value of this property to  **True** to automatically indent text when the text alignment in the cell is set, either horizontally or vertically, to equal distribution.
 
 To set text alignment to equal distribution, you can set the  **[VerticalAlignment](Excel.Range.VerticalAlignment.md)** property to **xlVAlignDistributed** when the value of the **[Orientation](Excel.Range.Orientation.md)** property is **xlVertical** , and you can set the **[HorizontalAlignment](Excel.Range.HorizontalAlignment.md)** property to **xlHAlignDistributed** when the value of the **Orientation** property is **xlHorizontal**.
 

--- a/api/Excel.TickLabels(object).md
+++ b/api/Excel.TickLabels(object).md
@@ -23,7 +23,7 @@ This object isn't a collection. There's no object that represents a single tick-
 
 Tick-mark label text for the category axis comes from the name of the associated category in the chart. The default tick-mark label text for the category axis is the number that indicates the position of the category relative to the left end of this axis. To change the number of unlabeled tick marks between tick-mark labels, you must change the  **[TickLabelSpacing](Excel.Axis.TickLabelSpacing.md)** property for the category axis.
 
-Tick-mark label text for the value axis is calculated based on the  **[MajorUnit](Excel.Axis.MajorUnit.md)**, **[MinimumScale](Excel.Axis.MinimumScale.md)**, and **[MaximumScale](Excel.Axis.MaximumScale.md)** properties of the value axis. To change the tick-mark label text for the value axis, you must change thte values of these properties.
+Tick-mark label text for the value axis is calculated based on the  **[MajorUnit](Excel.Axis.MajorUnit.md)**, **[MinimumScale](Excel.Axis.MinimumScale.md)**, and **[MaximumScale](Excel.Axis.MaximumScale.md)** properties of the value axis. To change the tick-mark label text for the value axis, you must change the values of these properties.
 
 
 ## Example

--- a/api/Excel.WebOptions.FolderSuffix.md
+++ b/api/Excel.WebOptions.FolderSuffix.md
@@ -73,7 +73,7 @@ The following table lists each language version of Office, and gives its corresp
 |Swedish|1053|-filer|
 |Thai|1054|.files|
 |Turkish|1055|_dosyalar|
-|Ukranian|1058|.files|
+|Ukrainian|1058|.files|
 |Vietnamese|1066|.files|
 
 ## Example

--- a/api/Excel.Workbook.Connections.md
+++ b/api/Excel.Workbook.Connections.md
@@ -26,7 +26,7 @@ _expression_ A variable that represents a [Workbook](./Excel.Workbook.md) object
 
 ## Example
 
-The following example rereshes the OBDC and OLEDB connections of the active workbook.
+The following example refreshes the OBDC and OLEDB connections of the active workbook.
 
 ```vb
 ActiveWorkbook.Connections(1).ODBCConnection.Refresh 

--- a/api/Excel.Workbook.FollowHyperlink.md
+++ b/api/Excel.Workbook.FollowHyperlink.md
@@ -36,7 +36,7 @@ _expression_. `FollowHyperlink`( `_Address_` , `_SubAddress_` , `_NewWindow_` , 
 | _AddHistory_|Optional| **Variant**|Not used. Reserved for future use.|
 | _ExtraInfo_|Optional| **Variant**|A  **String** or byte array that specifies additional information for HTTP to use to resolve the hyperlink. For example, you can use _ExtraInfo_ to specify the coordinates of an image map, the contents of a form, or a FAT file name.|
 | _Method_|Optional| **Variant**| Specifies the way _ExtraInfo_ is attached. Can be one of the **[MsoExtraInfoMethod](Office.MsoExtraInfoMethod.md)** constants.|
-| _HeaderInfo_|Optional| **Variant**|A  **String** that specifies header information for the HTTP request. The defaut value is an empty string.|
+| _HeaderInfo_|Optional| **Variant**|A  **String** that specifies header information for the HTTP request. The default value is an empty string.|
 
 ## Remarks
 

--- a/api/Excel.Workbook.Protect.md
+++ b/api/Excel.Workbook.Protect.md
@@ -32,7 +32,7 @@ _expression_ A variable that represents a [Workbook](./Excel.Workbook.md) object
 |:-----|:-----|:-----|:-----|
 | _Password_|Optional| **Variant**|A string that specifies a case-sensitive password for the worksheet or workbook. If this argument is omitted, you can unprotect the worksheet or workbook without using a password. Otherwise, you must specify the password to unprotect the worksheet or workbook. If you forget the password, you cannot unprotect the worksheet or workbook. Use strong passwords that combine uppercase and lowercase letters, numbers, and symbols. Weak passwords don't mix these elements. Strong password: Y6dh!et5. Weak password: House27. Passwords should be 8 or more characters in length. A pass phrase that uses 14 or more characters is better. For more information, see Help protect your personal information with strong passwords. It is critical that you remember your password. If you forget your password, Microsoft cannot retrieve it. Store the passwords that you write down in a secure place away from the information that they help protect. |
 | _Structure_|Optional| **Variant**| **True** to protect the structure of the workbook (the relative position of the sheets). The default value is **False**.|
-| _Windows_|Optional| **Variant**| **True** to protect the workbook windows. If this argument is omitted, the windows aren?t protected.|
+| _Windows_|Optional| **Variant**| **True** to protect the workbook windows. If this argument is omitted, the windows aren't protected.|
 
 ## See also
 

--- a/api/Excel.Workbook.SheetPivotTableAfterValueChange.md
+++ b/api/Excel.Workbook.SheetPivotTableAfterValueChange.md
@@ -32,7 +32,7 @@ _expression_ A variable that represents a '[Workbook](Excel.Workbook.md)' object
 |:-----|:-----|:-----|:-----|
 | _Sh_|Required| **Object**|The worksheet that contains the PivotTable.|
 | _TargetPivotTable_|Required| **[PivotTable](Excel.PivotTable.md)**|The PivotTable that contains the edited or recalculated cells.|
-| _TargetRange_|Required| **[Range](Excel.Range(object).md)**|The range that contains all the edited or recalcuated cells.|
+| _TargetRange_|Required| **[Range](Excel.Range(object).md)**|The range that contains all the edited or recalculated cells.|
 
 ## Return value
 

--- a/api/Excel.Worksheet.MailEnvelope.md
+++ b/api/Excel.Worksheet.MailEnvelope.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Worksheet.MailEnvelope property (Excel)
 
-Rrepresents an email header for a document.
+Represents an email header for a document.
 
 
 ## Syntax

--- a/api/Excel.Worksheet.PasteSpecial.md
+++ b/api/Excel.Worksheet.PasteSpecial.md
@@ -73,7 +73,7 @@ Worksheets("Sheet1").Range("F5").PasteSpecial _
 |0|"Picture (PNG)"|
 |1|"Picture (JPEG)"|
 |2|"Picture (GIF)"|
-|3|"Picture (Enghanced Metafile)"|
+|3|"Picture (Enhanced Metafile)"|
 |4|"Bitmap"|
 |5|"Microsoft Office Drawing Object"|
 

--- a/api/Excel.Worksheet.PivotTableAfterValueChange.md
+++ b/api/Excel.Worksheet.PivotTableAfterValueChange.md
@@ -31,7 +31,7 @@ _expression_ A variable that represents a '[Worksheet](Excel.Worksheet.md)' obje
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
 | _TargetPivotTable_|Required| **[PivotTable](Excel.PivotTable.md)**|The PivotTable that contains the edited or recalculated cells.|
-| _TargetRange_|Required| **[Range](Excel.Range(object).md)**|The range that contains all the edited or recalcuated cells.|
+| _TargetRange_|Required| **[Range](Excel.Range(object).md)**|The range that contains all the edited or recalculated cells.|
 
 ## Return value
 

--- a/api/Excel.Worksheet.PivotTableBeforeCommitChanges.md
+++ b/api/Excel.Worksheet.PivotTableBeforeCommitChanges.md
@@ -47,7 +47,7 @@ The  **PivotTableBeforeCommitChanges** event occurs immediately before Excel exe
 
 ## Example
 
-The following code example prompts the user before changes are commited to the PivotTable's OLAP data source.
+The following code example prompts the user before changes are committed to the PivotTable's OLAP data source.
 
 
 ```vb

--- a/api/Excel.Worksheet.PivotTableWizard.md
+++ b/api/Excel.Worksheet.PivotTableWizard.md
@@ -44,7 +44,7 @@ _expression_ A variable that represents a [Worksheet](./Excel.Worksheet.md) obje
 | _OptimizeCache_|Optional| **Variant**| **True** to optimize the PivotTable cache when it's constructed. The default value is **False**.|
 | _PageFieldOrder_|Optional| **Variant**|The order in which page fields are added to the PivotTable report?s layout. Can be one of the following  **xlOrder** constants: **xlDownThenOver** or **xlOverThenDown**. The default value is **xlDownThenOver**.|
 | _PageFieldWrapCount_|Optional| **Variant**|The number of page fields in each column or row in the PivotTable report. The default value is 0 (zero).|
-| _ReadData_|Optional| **Variant**| **True** to create a PivotTable cache that contains all records from the external database; this cache can be very large. If _ReadData_ is **False** , you can set some of the fields asserver-based page fields before the data is actually read.|
+| _ReadData_|Optional| **Variant**| **True** to create a PivotTable cache that contains all records from the external database; this cache can be very large. If _ReadData_ is **False** , you can set some of the fields as server-based page fields before the data is actually read.|
 | _Connection_|Optional| **Variant**|A string that contains ODBC settings that allow Excel to connect to an ODBC data source. The connection string has the form "ODBC;<connection string>". This argument overrides any previous setting for the  **[PivotCache](Excel.PivotCache.md)** object?s **[Connection](Excel.PivotCache.Connection.md)** property.|
 
 ## Return value

--- a/api/Excel.Worksheet.md
+++ b/api/Excel.Worksheet.md
@@ -86,7 +86,7 @@ Private Sub Worksheet_BeforeDoubleClick(ByVal Target As Range, Cancel As Boolean
    'If you did not double-click on A1, then exit the function.
    If Target.Address <> "$A$1" Then Exit Sub
    
-   'If you did double-click on A1, then override the default double-click behaviour with this function.
+   'If you did double-click on A1, then override the default double-click behavior with this function.
    Cancel = True
    
    'Set the path to the files, the path to Notepad, the file extension of the files, and the names of the files,

--- a/api/Excel.XlDataBarNegativeColorType.md
+++ b/api/Excel.XlDataBarNegativeColorType.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 
 # XlDataBarNegativeColorType enumeration (Excel)
 
-Specifies whether to use the same border and fill color as postive data bars.
+Specifies whether to use the same border and fill color as positive data bars.
 
 
 

--- a/api/Excel.XlDynamicFilterCriteria.md
+++ b/api/Excel.XlDynamicFilterCriteria.md
@@ -21,7 +21,7 @@ Specifies the filter criterion.
 | **xlFilterAllDatesInPeriodApril**|24|Filter all dates in April.|
 | **xlFilterAllDatesInPeriodAugust**|28|Filter all dates in August.|
 | **xlFilterAllDatesInPeriodDecember**|32|Filter all dates in December.|
-| **xlFilterAllDatesInPeriodFebruray**|22|Filter all dates in February.|
+| **xlFilterAllDatesInPeriodFebruary**|22|Filter all dates in February.|
 | **xlFilterAllDatesInPeriodJanuary**|21|Filter all dates in January.|
 | **xlFilterAllDatesInPeriodJuly**|27|Filter all dates in July.|
 | **xlFilterAllDatesInPeriodJune**|26|Filter all dates in June.|

--- a/api/Excel.XlFixedFormatQuality.md
+++ b/api/Excel.XlFixedFormatQuality.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 
 # XlFixedFormatQuality enumeration (Excel)
 
-Specifies the quality of speadsheets saved in different fixed formats.
+Specifies the quality of spreadsheets saved in different fixed formats.
 
 
 

--- a/api/Excel.XlPivotFieldCalculation.md
+++ b/api/Excel.XlPivotFieldCalculation.md
@@ -28,7 +28,7 @@ Specifies the type of calculation performed by a data PivotField when a custom c
 | **xlPercentOfParentRow**|10|Percentage of the total of the parent row.|
 | **xlPercentOfRow**|6|Percentage of the total for the row or category.|
 | **xlPercentOfTotal**|8|Percentage of the grand total of all the data or data points in the report.|
-| **xlPercentRunningTotal**|13|Percentatge of the running total of the specified Base field.|
+| **xlPercentRunningTotal**|13|Percentage of the running total of the specified Base field.|
 | **xlRankAscending**|14|Rank smallest to largest.|
 | **xlRankDecending**|15|Rank largest to smallest.|
 | **xlRunningTotal**|5|Data for successive items in the Base field as a running total.|

--- a/api/Excel.XlRemoveDocInfoType.md
+++ b/api/Excel.XlRemoveDocInfoType.md
@@ -31,7 +31,7 @@ Specifies the type information to be removed from the document information.
 | **xlRDIInkAnnotations**|11|Removes ink annotations from the document information.|
 | **xlRDIInlineWebExtensions**|21|Removes inline Web Extensions from the document information.|
 | **xlRDIPrinterPath**|20|Removes printer paths from the document information.|
-| **xlRDIPublishInfo**|13|Removes the pubish information data from the document information.|
+| **xlRDIPublishInfo**|13|Removes the publish information data from the document information.|
 | **xlRDIRemovePersonalInformation**|4|Removes personal information from the document information.|
 | **xlRDIRoutingSlip**|6|Removes routing slip information from the document information.|
 | **xlRDIScenarioComments**|12|Removes scenario comments from the document information.|

--- a/api/Excel.XlTrendlineType.md
+++ b/api/Excel.XlTrendlineType.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 
 # XlTrendlineType enumeration (Excel)
 
-Specifies how the trendline that smoothes out fluctuations in the data is calculated.
+Specifies how the trendline that smooths out fluctuations in the data is calculated.
 
 
 

--- a/api/Office.CommandBar.Visible.md
+++ b/api/Office.CommandBar.Visible.md
@@ -54,7 +54,7 @@ For Each cmdbar In CommandBars
     End If 
 Next 
 If Not foundFlag Then 
-    MsgBox "'Forms'command bar is not in the collection." 
+    MsgBox "'Forms' command bar is not in the collection." 
 End If
 ```
 

--- a/api/Office.CommandBarButton.Mask.md
+++ b/api/Office.CommandBarButton.Mask.md
@@ -36,7 +36,7 @@ Always set the mask after you have set the picture for a **CommandBarButton** ob
 
 ## Example
 
-The following example sets the image and mask of the first **CommandBarButton** that the code returns. To make this work, create a mask image and a button image and sustitute the paths in the sample with the paths to your images.
+The following example sets the image and mask of the first **CommandBarButton** that the code returns. To make this work, create a mask image and a button image and substitute the paths in the sample with the paths to your images.
 
 
 ```vb

--- a/api/Office.CommandBars.FindControls.md
+++ b/api/Office.CommandBars.FindControls.md
@@ -31,7 +31,7 @@ _expression_ A variable that represents a **[CommandBars](Office.CommandBars.md)
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _Type_|Optional|**Variant**|Is one of the **[MsoControlType](office.msocontroltype.md)** constants specfying the type of control.|
+| _Type_|Optional|**Variant**|Is one of the **[MsoControlType](office.msocontroltype.md)** constants specifying the type of control.|
 | _Id_|Optional|**Variant**|The control's identifier.|
 | _Tag_|Optional|**Variant**|The control's tag value.|
 | _Visible_|Optional|**Variant**|**True** to include only visible command bar controls in the search. The default value is **False**.|

--- a/api/Office.Font2.BaselineOffset.md
+++ b/api/Office.Font2.BaselineOffset.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 
 # Font2.BaselineOffset property (Office)
 
-Gets or sets a value specifying the horizontaol offset of the selected font. Read/write.
+Gets or sets a value specifying the horizontal offset of the selected font. Read/write.
 
 
 ## Syntax

--- a/api/Office.MsoCTPDockPositionRestrict.md
+++ b/api/Office.MsoCTPDockPositionRestrict.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 
 # MsoCTPDockPositionRestrict enumeration (Office)
 
-Specifies retrictions on the docking behavior of the custom task pane.
+Specifies restrictions on the docking behavior of the custom task pane.
 
 <br/>
 

--- a/api/Office.MsoChartElementType.md
+++ b/api/Office.MsoChartElementType.md
@@ -23,7 +23,7 @@ Specifies whether and how to display chart elements.
 |**msoElementChartTitleCenteredOverlay**|1|Display title as centered overlay.|
 |**msoElementChartTitleNone**|0|Do not display chart title.|
 |**msoElementChartWallNone**|1100|Do not display chart wall.|
-|**msoElementChartWallShow**|1101|Dispaly chart wall.|
+|**msoElementChartWallShow**|1101|Display chart wall.|
 |**msoElementDataLabelBestFit**|210|Use best fit for data label.|
 |**msoElementDataLabelBottom**|209|Display data label at bottom.|
 |**msoElementDataLabelCallout**|211|Display data label as a callout.|
@@ -98,8 +98,8 @@ Specifies whether and how to display chart elements.
 |**msoElementSecondaryCategoryAxisReverse**|361|Reverse secondary category axis.|
 |**msoElementSecondaryCategoryAxisShow**|359|Display secondary category axis.|
 |**msoElementSecondaryCategoryAxisThousands**|376|Use thousands for secondary category axis units.|
-|**msoElementSecondaryCategoryAxisTitleAdjacentToAxis**|313|Dispaly secondary category axis title adjacent to axis.|
-|**msoElementSecondaryCategoryAxisTitleBelowAxis**|314|Dispaly secondary category axis title below axis.|
+|**msoElementSecondaryCategoryAxisTitleAdjacentToAxis**|313|Display secondary category axis title adjacent to axis.|
+|**msoElementSecondaryCategoryAxisTitleBelowAxis**|314|Display secondary category axis title below axis.|
 |**msoElementSecondaryCategoryAxisTitleHorizontal**|317|Display secondary category axis title horizontally.|
 |**msoElementSecondaryCategoryAxisTitleNone**|312|Do not display secondary category axis title.|
 |**msoElementSecondaryCategoryAxisTitleRotated**|315|Rotate secondary category axis title.|

--- a/api/Office.MsoPictureEffectType.md
+++ b/api/Office.MsoPictureEffectType.md
@@ -32,7 +32,7 @@ Specifies constants that define the types of picture effects.
 |**msoEffectLightScreen**|13|Light screen effect |
 |**msoEffectLineDrawing**|14|Line drawing effect |
 |**msoEffectMarker**|15|Marker effect |
-|**msoEffectMosiacBubbles**|16|Mosaic bubbles |
+|**msoEffectMosaicBubbles**|16|Mosaic bubbles |
 |**msoEffectNone**|17|No effect |
 |**msoEffectPaintBrush**|18|Paintbrush effect |
 |**msoEffectPaintStrokes**|19|Paint strokes effect |

--- a/api/Office.MsoTextCharWrap.md
+++ b/api/Office.MsoTextCharWrap.md
@@ -20,7 +20,7 @@ Indicates the type of text wrap.
 |**msoCharWrapMixed**|-2|Specifies a mixed text wrap.|
 |**msoCustomCharWrap**|3|Specifies a custom text wrap scheme.|
 |**msoNoCharWrap**|0|Specifies no text wrapping.|
-|**msoStandardCharWrap**|1|Specifies wrapping text around the standard boundry of an object.|
+|**msoStandardCharWrap**|1|Specifies wrapping text around the standard boundary of an object.|
 |**msoStrictCharWrap**|2|Specifies text wrapping that adheres to restrictions imposed by some languages such as Chinese and Japanese alphabets.|
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Office.SharedWorkspaceTask.Save.md
+++ b/api/Office.SharedWorkspaceTask.Save.md
@@ -31,7 +31,7 @@ _expression_ A variable that represents a **[SharedWorkspaceTask](Office.SharedW
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _bstrQueryName_|Required|**String**|Name of the query used to change the property of the shared workspcae link.|
+| _bstrQueryName_|Required|**String**|Name of the query used to change the property of the shared workspace link.|
 
 ## Remarks
 

--- a/api/Office.Signature.Sign.md
+++ b/api/Office.Signature.Sign.md
@@ -47,7 +47,7 @@ In the following example, the variables for the signature image, signer, signer'
 Set objSignature = New Signature 
 varSigline = CType(AxHost2.GetIPictureDispFromPicture(img),IPictureDisp) 
 varSuggestedSigner = "Nancy Davolio" 
-varSignatureTitle = "Sales Represenative" 
+varSignatureTitle = "Sales Representative" 
 varSignerEmail = "ndavolio@northwindtraders.com" 
 objSignature.Sign(varSigline, varSuggestedSigner, varSignatureTitle, varSignerEmail)
 ```

--- a/api/Outlook.AppointmentItem.EndUTC.md
+++ b/api/Outlook.AppointmentItem.EndUTC.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # AppointmentItem.EndUTC Property (Outlook)
 
-Returns or sets a  **Date** value that represents the end date and time of the appointment expressed in the Coordinated Univeral Time (UTC) standard. Read/write.
+Returns or sets a  **Date** value that represents the end date and time of the appointment expressed in the Coordinated Universal Time (UTC) standard. Read/write.
 
 
 ## Syntax

--- a/api/Outlook.AppointmentItem.InternetCodepage.md
+++ b/api/Outlook.AppointmentItem.InternetCodepage.md
@@ -68,7 +68,7 @@ The following table lists the values that are supported by the  **InternetCodePa
 |Western European (ISO)| iso-8859-1|28591|
 |Western European (Windows)|Windows-1252|1252|
 
-The following table lists the code pages Microsoft recommends that you use for the best compatiblity with older email systems.
+The following table lists the code pages Microsoft recommends that you use for the best compatibility with older email systems.
 
 
 

--- a/api/Outlook.AppointmentItem.StartUTC.md
+++ b/api/Outlook.AppointmentItem.StartUTC.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # AppointmentItem.StartUTC Property (Outlook)
 
-Returns or sets a  **Date** value that represents the start date and time of the appointment expressed in the Coordinated Univeral Time (UTC) standard. Read/write.
+Returns or sets a  **Date** value that represents the start date and time of the appointment expressed in the Coordinated Universal Time (UTC) standard. Read/write.
 
 
 ## Syntax

--- a/api/Outlook.Conflicts.md
+++ b/api/Outlook.Conflicts.md
@@ -21,7 +21,7 @@ Contains a collection of  **[Conflict](Outlook.Conflict.md)** objects that repre
 
 Use the  **[Conflicts](Outlook.MailItem.Conflicts.md)** property of any Outlook item, such as **[MailItem](Outlook.MailItem.md)**, to return the **Conflicts** object.
 
-Use the  **[Count](Outlook.Conflicts.Count.md)** property of the **Conflicts** object to determine if the item is invloved in a conflict. A non-zero value indicates conflict.
+Use the  **[Count](Outlook.Conflicts.Count.md)** property of the **Conflicts** object to determine if the item is involved in a conflict. A non-zero value indicates conflict.
 
 Use the  **[Item](Outlook.Conflicts.Item.md)** method to retrieve a particular conflict item from the **Conflicts** collection object.
 

--- a/api/Outlook.Conversation.GetAlwaysDelete.md
+++ b/api/Outlook.Conversation.GetAlwaysDelete.md
@@ -34,7 +34,7 @@ _expression_ A variable that represents a '[Conversation](Outlook.Conversation.m
 
 ## Return value
 
-A constant from the  **OlAlwaysDeleteConversation** enumeration that indicates whether all new items of the conversation are always moved to the Deleted Items folder of the specified delivey store.
+A constant from the  **OlAlwaysDeleteConversation** enumeration that indicates whether all new items of the conversation are always moved to the Deleted Items folder of the specified delivery store.
 
 
 ## Remarks

--- a/api/Outlook.Explorer.Selection.md
+++ b/api/Outlook.Explorer.Selection.md
@@ -89,7 +89,7 @@ Sub GetSelectedItems()
  
  ElseIf myOlSel.Item(x).Class = OlObjectClass.olAppointment Then 
  
- ' For appointment item, use the Organizser property. 
+ ' For appointment item, use the Organizer property. 
  
  Set oAppt = myOlSel.Item(x) 
  

--- a/api/Outlook.Folder.AddressBookName.md
+++ b/api/Outlook.Folder.AddressBookName.md
@@ -45,7 +45,7 @@ Sub BookName()
  
  
  
- 'Create a reference to namepsace 
+ 'Create a reference to namespace 
  
  Set nmsName = Application.GetNamespace("MAPI") 
  

--- a/api/Outlook.Folder.GetTable.md
+++ b/api/Outlook.Folder.GetTable.md
@@ -30,7 +30,7 @@ _expression_ A variable that represents a '[Folder](Outlook.Folder.md)' object.
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _Filter_|Optional| **String**|A filter in Microsft Jet or DAV Searching and Locating (DASL) syntax that specifies the criteria for items in the parent  **Folder**.|
+| _Filter_|Optional| **String**|A filter in Microsoft Jet or DAV Searching and Locating (DASL) syntax that specifies the criteria for items in the parent  **Folder**.|
 | _TableContents_|Optional| **[OlTableContents](Outlook.OlTableContents.md)**|Specifies the type of items in the folder that  **GetTable** returns. The default is **olUserItems**.|
 
 ## Return value

--- a/api/Outlook.FormRegion.Select.md
+++ b/api/Outlook.FormRegion.Select.md
@@ -26,7 +26,7 @@ _expression_ A variable that represents a [FormRegion](./Outlook.FormRegion.md) 
 
 ## Remarks
 
-If the form region is an adjoining form region, then  **Select** will expand the form region (if it is not already expanded) and set focus on the first control on that page. If the form region is a separate form region and is not already the active page, then **Select** will swtich to the form region page and set focus on the first control on that page. If the form region is a separate form region and is already the active page, then nothing happens.
+If the form region is an adjoining form region, then  **Select** will expand the form region (if it is not already expanded) and set focus on the first control on that page. If the form region is a separate form region and is not already the active page, then **Select** will switch to the form region page and set focus on the first control on that page. If the form region is a separate form region and is already the active page, then nothing happens.
 
 
 ## See also

--- a/api/Outlook.Items.Find.md
+++ b/api/Outlook.Items.Find.md
@@ -58,7 +58,7 @@ The method will return an error with the following properties in the  _Filter_ :
 | **DLName**| **RecurrenceState**|
 | **Email1EntryID**| **ReplyRecipients**|
 | **Email2EntryID**| **ReceivedByEntryID**|
-| **Email3EntryID**| **RecevedOnBehalfOfEntryID**|
+| **Email3EntryID**| **ReceivedOnBehalfOfEntryID**|
 | **EntryID**| **ResponseState**|
 | **HTMLBody**| **Saved**|
 | **IsOnlineMeeting**| **Sent**|

--- a/api/Outlook.Items.Restrict.md
+++ b/api/Outlook.Items.Restrict.md
@@ -60,7 +60,7 @@ This method cannot be used and will cause an error with the following properties
 | **ConversationIndex**| **NetMeetingType**|
 | **DLName**| **RecurrenceState**|
 | **Email1EntryID**| **ReceivedByEntryID**|
-| **Email2EntryID**| **RecevedOnBehalfOfEntryID**|
+| **Email2EntryID**| **ReceivedOnBehalfOfEntryID**|
 | **Email3EntryID**| **ReplyRecipients**|
 | **EntryID**| **ResponseState**|
 | **HTMLBody**| **Saved**|

--- a/api/Outlook.JournalItem.DocPrinted.md
+++ b/api/Outlook.JournalItem.DocPrinted.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # JournalItem.DocPrinted Property (Outlook)
 
-Returns a  **Boolean** value that indicates wheter the journalized item was printed as part of the journalized session. Read/write.
+Returns a  **Boolean** value that indicates whether the journalized item was printed as part of the journalized session. Read/write.
 
 
 ## Syntax

--- a/api/Outlook.MailItem.InternetCodepage.md
+++ b/api/Outlook.MailItem.InternetCodepage.md
@@ -68,7 +68,7 @@ The following table lists the values that are supported by the  **InternetCodePa
 |Western European (ISO)| iso-8859-1|28591|
 |Western European (Windows)|Windows-1252|1252|
 
-The following table lists the code pages Microsoft recommends that you use for the best compatiblity with older email systems.
+The following table lists the code pages Microsoft recommends that you use for the best compatibility with older email systems.
 
 
 

--- a/api/Outlook.MailModule.Position.md
+++ b/api/Outlook.MailModule.Position.md
@@ -28,7 +28,7 @@ _expression_ A variable that represents a [MailModule](./Outlook.MailModule.md) 
 
 This property can only be set to a value between 1 and 9. An error occurs if you attempt to set this property to a value outside that range.
 
-Changing the value of this property for a given  **MailModule** object changes the **Position** values of other navigaton modules in a **[NavigationModules](Outlook.NavigationModules.md)** collection, depending on the relative change between the new value and the original value.
+Changing the value of this property for a given  **MailModule** object changes the **Position** values of other navigation modules in a **[NavigationModules](Outlook.NavigationModules.md)** collection, depending on the relative change between the new value and the original value.
 
 
 - If the new value is less than the original value, the specified  **MailModule** object moves up to the new position and the other navigation modules that are already at or below that new position move down.

--- a/api/Outlook.NameSpace.Logon.md
+++ b/api/Outlook.NameSpace.Logon.md
@@ -31,7 +31,7 @@ _expression_ A variable that represents a [NameSpace](./Outlook.NameSpace.md) ob
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
 | _Profile_|Optional| **Variant**|The MAPI profile name, as a  **String** , to use for the session. Specify an empty string to use the default profile for the current session.|
-| _Password_|Optional| **Variant**|The password (if any), as a  **String** , associated with the profile. This parameter exists only for backwards compatibility and for security reasons, it is not recommended for use. Microsoft Oultook will prompt the user to specify a password in most system configurations. This is your logon password and should not be confused with PST passwords.|
+| _Password_|Optional| **Variant**|The password (if any), as a  **String** , associated with the profile. This parameter exists only for backwards compatibility and for security reasons, it is not recommended for use. Microsoft Outlook will prompt the user to specify a password in most system configurations. This is your logon password and should not be confused with PST passwords.|
 | _ShowDialog_|Optional| **Variant**| **True** to display the MAPI logon dialog box to allow the user to select a MAPI profile.|
 | _NewSession_|Optional| **Variant**| **True** to create a new Microsoft Outlook session. Since multiple sessions cannot be created in Outlook, this parameter should be specified as True only if a session does not already exist.|
 

--- a/api/Outlook.OlColor.md
+++ b/api/Outlook.OlColor.md
@@ -24,7 +24,7 @@ Constants that represent colors.
 | **olColorAqua**|15|Aqua|
 | **olColorBlack**|1|Black|
 | **olColorBlue**|13|Blue|
-| **olColorFuchsia**|14|Fuschsia|
+| **olColorFuchsia**|14|Fuchsia|
 | **olColorGray**|8|Gray|
 | **olColorGreen**|3|Green|
 | **olColorLime**|11|Lime|

--- a/api/Outlook.OlContactPhoneNumber.md
+++ b/api/Outlook.OlContactPhoneNumber.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # OlContactPhoneNumber Enumeration (Outlook)
 
-Specfies the telephone number type.
+Specifies the telephone number type.
 
 
 

--- a/api/Outlook.OlkComboBox.ListIndex.md
+++ b/api/Outlook.OlkComboBox.ListIndex.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # OlkComboBox.ListIndex Property (Outlook)
 
-Reurns or sets a  **Long** that indicates the location of the currently selected element in the list of the combo box control. Read/write.
+Returns or sets a  **Long** that indicates the location of the currently selected element in the list of the combo box control. Read/write.
 
 
 ## Syntax

--- a/api/Outlook.PostItem.InternetCodepage.md
+++ b/api/Outlook.PostItem.InternetCodepage.md
@@ -68,7 +68,7 @@ The following table lists the values that are supported by the  **InternetCodePa
 |Western European (ISO)|iso-8859-1|28591|
 |Western European (Windows)|Windows-1252|1252|
 
-The following table lists the code pages Microsoft recommends that you use for the best compatiblity with older email systems.
+The following table lists the code pages Microsoft recommends that you use for the best compatibility with older email systems.
 
 
 

--- a/api/Outlook.Rules.Create.md
+++ b/api/Outlook.Rules.Create.md
@@ -47,7 +47,7 @@ When a rule is added to the collection, the  **[Rule.ExecutionOrder](Outlook.Rul
 
 ## Example
 
-The following code sample in Visual Basic for Applicatons (VBA) uses the Rules object model to create a rule. The code sample uses the  **[RuleAction](Outlook.RuleAction.md)** and **[RuleCondition](Outlook.RuleCondition.md)** objects to specify a rule that forwards messages from a specific sender to a specific folder, unless the message contains certain terms in the subject. Note that the code sample assumes that there already exists a folder "Dan" under the Inbox.
+The following code sample in Visual Basic for Applications (VBA) uses the Rules object model to create a rule. The code sample uses the  **[RuleAction](Outlook.RuleAction.md)** and **[RuleCondition](Outlook.RuleCondition.md)** objects to specify a rule that forwards messages from a specific sender to a specific folder, unless the message contains certain terms in the subject. Note that the code sample assumes that there already exists a folder "Dan" under the Inbox.
 
 
 ```vb

--- a/api/Outlook.SharingItem.InternetCodepage.md
+++ b/api/Outlook.SharingItem.InternetCodepage.md
@@ -68,7 +68,7 @@ The following table lists the values that are supported by the  **InternetCodepa
 |Western European (ISO)|iso-8859-1|28591|
 |Western European (Windows)|windows-1252|1252|
 
-The following table lists the code pages Microsoft recommends that you use for the best compatiblity with older email systems.
+The following table lists the code pages Microsoft recommends that you use for the best compatibility with older email systems.
 
 
 

--- a/api/Outlook.StorageItem.Creator.md
+++ b/api/Outlook.StorageItem.Creator.md
@@ -26,7 +26,7 @@ _expression_ A variable that represents a [StorageItem](./Outlook.StorageItem.md
 
 ## Remarks
 
-Outlook does not set the  **Creator** property. Use the **Creator** property to identify the **StorageItem** objects you have created for your add-in. One recomended value for this property is the programmatic identifier (ProgID) of the add-in.
+Outlook does not set the  **Creator** property. Use the **Creator** property to identify the **StorageItem** objects you have created for your add-in. One recommended value for this property is the programmatic identifier (ProgID) of the add-in.
 
 
 ## See also

--- a/api/Outlook.TaskItem.InternetCodepage.md
+++ b/api/Outlook.TaskItem.InternetCodepage.md
@@ -68,7 +68,7 @@ The following table lists the values that are supported by the  **InternetCodePa
 |Western European (ISO)|iso-8859-1|28591|
 |Western European (Windows) |Windows-1252|1252|
 
-The following table lists the code pages Microsoft recommends that you use for the best compatiblity with older email systems.
+The following table lists the code pages Microsoft recommends that you use for the best compatibility with older email systems.
 
 
 

--- a/api/Outlook.ToOrFromRuleCondition.md
+++ b/api/Outlook.ToOrFromRuleCondition.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # ToOrFromRuleCondition Object (Outlook)
 
-Represents a rule condition that the sender or the recipeints of the message, as specified by  **[ToOrFromRuleCondition.ConditionType](Outlook.ToOrFromRuleCondition.ConditionType.md)**, is in the recipients list specified in **[ToOrFromRuleCondition.Recipients](Outlook.ToOrFromRuleCondition.Recipients.md)**.
+Represents a rule condition that the sender or the recipients of the message, as specified by  **[ToOrFromRuleCondition.ConditionType](Outlook.ToOrFromRuleCondition.ConditionType.md)**, is in the recipients list specified in **[ToOrFromRuleCondition.Recipients](Outlook.ToOrFromRuleCondition.Recipients.md)**.
 
 
 ## Remarks

--- a/api/Outlook.View.ViewType.md
+++ b/api/Outlook.View.ViewType.md
@@ -31,7 +31,7 @@ This property does not have any effect on the icons displayed in the Shortcuts p
 
 ## Example
 
-The following Visual Basic for Applicatons (VBA) example displays the name and type of all views in the user's  **Inbox**.
+The following Visual Basic for Applications (VBA) example displays the name and type of all views in the user's  **Inbox**.
 
 
 ```vb

--- a/api/PowerPoint.AnimationBehavior.PropertyEffect.md
+++ b/api/PowerPoint.AnimationBehavior.PropertyEffect.md
@@ -41,7 +41,7 @@ Sub AddShapeSetAnimFill()
     Dim shpRectangle As Shape
     Dim animBlinds As AnimationBehavior
 
-    'Adds rectangle and sets animiation effect
+    'Adds rectangle and sets animation effect
     Set shpRectangle = ActivePresentation.Slides(1).Shapes _
         .AddShape(Type:=msoShapeRectangle, Left:=100, _
         Top:=100, Width:=50, Height:=50)

--- a/api/PowerPoint.AnimationBehavior.Type.md
+++ b/api/PowerPoint.AnimationBehavior.Type.md
@@ -41,7 +41,7 @@ The value of the  **Type** property can be one of these **MsoAnimType** constant
 |**MsoAnimTypeMotion**|
 |**MsoAnimTypeNone**|
 |**MsoAnimTypeProperty**|
-|**MsoAnimTypeRoatation**|
+|**MsoAnimTypeRotation**|
 |**MsoAnimTypeScale**|
 |**MsoAnimTypeTransition**|
 

--- a/api/PowerPoint.AnimationBehaviors.Add.md
+++ b/api/PowerPoint.AnimationBehaviors.Add.md
@@ -31,7 +31,7 @@ _expression_ A variable that represents an [AnimationBehaviors](./PowerPoint.Ani
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
 | _Type_|Required|**MsoAnimType**|The type of the animation behavior.|
-| _Index_|Optional|**Long**|The position of the animation behaviorce in relation to other animation behaviors. The default value is -1, which means that if you omit the  _Index_ parameter, the new animation behavior is added at the end of the existing animation behaviors.|
+| _Index_|Optional|**Long**|The position of the animation behavior in relation to other animation behaviors. The default value is -1, which means that if you omit the  _Index_ parameter, the new animation behavior is added at the end of the existing animation behaviors.|
 
 ## Return value
 

--- a/api/PowerPoint.AnimationPoint.Formula.md
+++ b/api/PowerPoint.AnimationPoint.Formula.md
@@ -41,7 +41,7 @@ Sub AddShapeSetAnimFill()
     Dim shpRectangle As Shape
     Dim animBlinds As AnimationBehavior
 
-    'Adds rectangle and sets animiation effect
+    'Adds rectangle and sets animation effect
     Set shpRectangle = ActivePresentation.Slides(1).Shapes _
         .AddShape(Type:=msoShapeRectangle, Left:=100, _
         Top:=100, Width:=50, Height:=50)

--- a/api/PowerPoint.AnimationPoints.md
+++ b/api/PowerPoint.AnimationPoints.md
@@ -29,7 +29,7 @@ Sub AddPoint()
 End Sub
 ```
 
-Transitions from one animation point to another can sometimes be abrupt or choppy. Use the [Smooth](PowerPoint.AnimationPoints.Smooth.md)property to make transitions smoother. This example smoothes the transitions between animation points.
+Transitions from one animation point to another can sometimes be abrupt or choppy. Use the [Smooth](PowerPoint.AnimationPoints.Smooth.md)property to make transitions smoother. This example smooths the transitions between animation points.
 
 
 

--- a/api/PowerPoint.CommandEffect.Type.md
+++ b/api/PowerPoint.CommandEffect.Type.md
@@ -41,7 +41,7 @@ The value of the  **Type** property can be one of these **MsoAnimType** constant
 |**MsoAnimTypeMotion**|
 |**MsoAnimTypeNone**|
 |**MsoAnimTypeProperty**|
-|**MsoAnimTypeRoatation**|
+|**MsoAnimTypeRotation**|
 |**MsoAnimTypeScale**|
 |**MsoAnimTypeTransition**|
 

--- a/api/PowerPoint.CustomerData.Delete.md
+++ b/api/PowerPoint.CustomerData.Delete.md
@@ -39,7 +39,7 @@ Individual  **CustomXMLPart** objects in the **CustomerData** collection are rep
 
 ## Example
 
-The following example shows how to use the Delete method to delete a custom XML part from the  **CustomerData** collection. It adds a new custom XML part to the **CustomerData** collection of the first shape on the first slide of the active presentaion. Then it gets the ID of the new part and passes it to the **Delete** method.
+The following example shows how to use the Delete method to delete a custom XML part from the  **CustomerData** collection. It adds a new custom XML part to the **CustomerData** collection of the first shape on the first slide of the active presentation. Then it gets the ID of the new part and passes it to the **Delete** method.
 
 
 ```vb

--- a/api/PowerPoint.FileConverters.md
+++ b/api/PowerPoint.FileConverters.md
@@ -36,7 +36,7 @@ Next conv
 
 The  **Add** method isn't available for the **FileConverters** collection. **[FileConverter](PowerPoint.FileConverter.md)** objects are added during installation of Microsoft Office or by installing supplemental converters.
 
-Use  **FileConverters** (Index), where Index is a class name or index number, to return a single **[FileConverter](PowerPoint.FileConverter.md)** object. The following example displays the extensions associated wtih the Microsoft Excel worksheet converter.
+Use  **FileConverters** (Index), where Index is a class name or index number, to return a single **[FileConverter](PowerPoint.FileConverter.md)** object. The following example displays the extensions associated with the Microsoft Excel worksheet converter.
 
 
 

--- a/api/PowerPoint.FillFormat.Patterned.md
+++ b/api/PowerPoint.FillFormat.Patterned.md
@@ -30,7 +30,7 @@ Sets the specified fill to a pattern.
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _Pattern_|Required|**MsoPatternType**|The pattern to be used for the specified fill. See Reamrks for possible values.|
+| _Pattern_|Required|**MsoPatternType**|The pattern to be used for the specified fill. See Remarks for possible values.|
 
 ## Remarks
 

--- a/api/PowerPoint.FilterEffect.Type.md
+++ b/api/PowerPoint.FilterEffect.Type.md
@@ -41,7 +41,7 @@ The value of the  **Type** property can be one of these **MsoAnimType** constant
 |**MsoAnimTypeMotion**|
 |**MsoAnimTypeNone**|
 |**MsoAnimTypeProperty**|
-|**MsoAnimTypeRoatation**|
+|**MsoAnimTypeRotation**|
 |**MsoAnimTypeScale**|
 |**MsoAnimTypeTransition**|
 

--- a/api/PowerPoint.Hyperlink.TextToDisplay.md
+++ b/api/PowerPoint.Hyperlink.TextToDisplay.md
@@ -33,7 +33,11 @@ String
 
 This property will cause a run-time error if used with a hyperlink that is not associated with a text range. You can use code similar to the following to test whether or not a given hyperlink, represented here by  `myHyperlink`, is associated with a text range.
 
- `If TypeName(myHyperlink.Parent.Parent) = "TextRange" Then strTRtest = "True" End If`
+```vb
+If TypeName(myHyperlink.Parent.Parent) = "TextRange" Then
+    strTRtest = "True"
+End If
+```
 
 
 ## Example

--- a/api/PowerPoint.LineFormat.EndArrowheadStyle.md
+++ b/api/PowerPoint.LineFormat.EndArrowheadStyle.md
@@ -31,7 +31,7 @@ MsoArrowheadStyle
 
 ## Remarks
 
-The  **EndArrowheadStyle** proerty value can be one of these **MsoArrowheadStyle** constants.
+The  **EndArrowheadStyle** property value can be one of these **MsoArrowheadStyle** constants.
 
 
 ||

--- a/api/PowerPoint.LineFormat.InsetPen.md
+++ b/api/PowerPoint.LineFormat.InsetPen.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # LineFormat.InsetPen Property (PowerPoint)
 
-Detemines whether to draw lines on the inside of a specified shape. Read/write.
+Determines whether to draw lines on the inside of a specified shape. Read/write.
 
 
 ## Syntax

--- a/api/PowerPoint.Presentation.ExportAsFixedFormat.md
+++ b/api/PowerPoint.Presentation.ExportAsFixedFormat.md
@@ -98,7 +98,7 @@ The  _OutputType_ parameter value can be a combination of one or more of these *
 |**ppPrintOutputNineSlideHandouts**|Prints nine slides per handout page.|
 |**ppPrintOutputNotesPages**|Prints notes pages.|
 |**ppPrintOutputOneSlideHandouts**|Prints one slide per handout page.|
-|**ppPrintOutputOutline**|Prints outine view.|
+|**ppPrintOutputOutline**|Prints outline view.|
 |**ppPrintOutputSixSlideHandouts**|Prints six slides per handout page.|
 |**ppPrintOutputSlides**|Prints all slides in the presentation. The default.|
 |**ppPrintOutputThreeSlideHandouts**|Prints three slides per handout page.|

--- a/api/PowerPoint.Shape.Shadow.md
+++ b/api/PowerPoint.Shape.Shadow.md
@@ -30,9 +30,9 @@ This example adds a shadowed rectangle to slide one in the active presentation. 
 
 
 ```vb
-Set myShap = Application.ActivePresentation.Slides(1).Shapes
+Set myShape = Application.ActivePresentation.Slides(1).Shapes
 
-With myShap.AddShape(msoShapeRectangle, 10, 10, 150, 90).Shadow
+With myShape.AddShape(msoShapeRectangle, 10, 10, 150, 90).Shadow
 
     .Type = msoShadow17
 

--- a/api/PowerPoint.Shape.Vertices.md
+++ b/api/PowerPoint.Shape.Vertices.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Shape.Vertices Property (PowerPoint)
 
-Returns the coordinates of the specified freeform drawing's vertices (and control points for B?zier curves) as a series of coordinate pairs. Read-only.
+Returns the coordinates of the specified freeform drawing's vertices (and control points for Bézier curves) as a series of coordinate pairs. Read-only.
 
 
 ## Syntax

--- a/api/PowerPoint.ShapeRange.Shadow.md
+++ b/api/PowerPoint.ShapeRange.Shadow.md
@@ -30,9 +30,9 @@ This example adds a shadowed rectangle to slide one in the active presentation. 
 
 
 ```vb
-Set myShap = Application.ActivePresentation.Slides(1).Shapes
+Set myShape = Application.ActivePresentation.Slides(1).Shapes
 
-With myShap.AddShape(msoShapeRectangle, 10, 10, 150, 90).Shadow
+With myShape.AddShape(msoShapeRectangle, 10, 10, 150, 90).Shadow
 
     .Type = msoShadow17
 

--- a/api/PowerPoint.ShapeRange.Vertices.md
+++ b/api/PowerPoint.ShapeRange.Vertices.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # ShapeRange.Vertices Property (PowerPoint)
 
-Returns the coordinates of the specified freeform drawing's vertices (and control points for B?zier curves) as a series of coordinate pairs. Read-only.
+Returns the coordinates of the specified freeform drawing's vertices (and control points for Bézier curves) as a series of coordinate pairs. Read-only.
 
 
 ## Syntax

--- a/api/PowerPoint.Shapes.AddCurve.md
+++ b/api/PowerPoint.Shapes.AddCurve.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Shapes.AddCurve Method (PowerPoint)
 
-Creates a B?zier curve. Returns a  **[Shape](PowerPoint.Shape.md)** object that represents the new curve.
+Creates a Bézier curve. Returns a  **[Shape](PowerPoint.Shape.md)** object that represents the new curve.
 
 
 ## Syntax
@@ -30,7 +30,7 @@ Creates a B?zier curve. Returns a  **[Shape](PowerPoint.Shape.md)** object that 
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _SafeArrayOfPoints_|Required|**Variant**|An array of coordinate pairs that specifies the vertices and control points of the curve. The first point you specify is the starting vertex, and the next two points are control points for the first B?zier segment. Then, for each additional segment of the curve, you specify a vertex and two control points. The last point you specify is the ending vertex for the curve. Note that you must always specify 3n + 1 points, where n is the number of segments in the curve.|
+| _SafeArrayOfPoints_|Required|**Variant**|An array of coordinate pairs that specifies the vertices and control points of the curve. The first point you specify is the starting vertex, and the next two points are control points for the first Bézier segment. Then, for each additional segment of the curve, you specify a vertex and two control points. The last point you specify is the ending vertex for the curve. Note that you must always specify 3n + 1 points, where n is the number of segments in the curve.|
 
 ## Return value
 
@@ -39,7 +39,7 @@ Shape
 
 ## Example
 
-The following example adds a two-segment B?zier curve to myDocument.
+The following example adds a two-segment Bézier curve to myDocument.
 
 
 ```vb

--- a/api/PowerPoint.Table.FirstRow.md
+++ b/api/PowerPoint.Table.FirstRow.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Table.FirstRow Property (PowerPoint)
 
-Determinew whether to display special formatting for the first row of the specified table. Read/write.
+Determine whether to display special formatting for the first row of the specified table. Read/write.
 
 
 ## Syntax

--- a/api/PowerPoint.TimeLine.InteractiveSequences.md
+++ b/api/PowerPoint.TimeLine.InteractiveSequences.md
@@ -40,7 +40,7 @@ The following example adds an interactive sequence to the first slide and sets t
 
 
 ```vb
-Sub NewInteractiveSeqence()
+Sub NewInteractiveSequence()
 
     Dim seqInteractive As Sequence
     Dim shpText As Shape

--- a/api/PowerPoint.Timing.Decelerate.md
+++ b/api/PowerPoint.Timing.Decelerate.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Timing.Decelerate Property (PowerPoint)
 
-Sets or returns the percentageof the duration over which a timing deceleration should take place. Read/write.
+Sets or returns the percentage of the duration over which a timing deceleration should take place. Read/write.
 
 
 ## Syntax

--- a/api/PowerPoint.XlPattern.md
+++ b/api/PowerPoint.XlPattern.md
@@ -35,7 +35,7 @@ Specifies the interior pattern of a chart or interior object.
 |**xlPatternLinearGradient**|4000|A linear gradient.|
 |**xlPatternNone**|-4142|No pattern.|
 |**xlPatternRectangularGradient**|4001|A rectangular gradient.|
-|**xlPatternSemiGray75**|10|75% dark moir?.|
+|**xlPatternSemiGray75**|10|75% dark moiré.|
 |**xlPatternSolid**|1|A solid color.|
 |**xlPatternUp**|-4162|Dark diagonal lines running from the lower left to the upper right.|
 |**xlPatternVertical**|-4166|Dark vertical bars.|

--- a/api/PowerPoint.XlTrendlineType.md
+++ b/api/PowerPoint.XlTrendlineType.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 
 # XlTrendlineType Enumeration (PowerPoint)
 
-Specifies how the trendline that smoothes out fluctuations in the data is calculated.
+Specifies how the trendline that smooths out fluctuations in the data is calculated.
 
 
 

--- a/api/Project.Application.CalendarDateShadingEdit.md
+++ b/api/Project.Application.CalendarDateShadingEdit.md
@@ -53,7 +53,7 @@ To edit calendar date boxes where the colors can be RGB values, use the  **[Cale
 
 ## Example
 
-The following example changes the background color of working days in the base calander to a stippled purple and the color of nonworking days to gray.
+The following example changes the background color of working days in the base calendar to a stippled purple and the color of nonworking days to gray.
 
 
 ```vb

--- a/api/Project.Application.CalendarDateShadingEditEx.md
+++ b/api/Project.Application.CalendarDateShadingEditEx.md
@@ -51,7 +51,7 @@ Besides  _Item_, **CalendarDateShadingEditEx** requires either the _Pattern_ or 
 
 ## Example
 
-The following example changes the background color of working days in the base calander to a stippled purple and the color of nonworking days to light gray.
+The following example changes the background color of working days in the base calendar to a stippled purple and the color of nonworking days to light gray.
 
 
 ```vb

--- a/api/Project.Application.FilePageSetupCalendar.md
+++ b/api/Project.Application.FilePageSetupCalendar.md
@@ -54,13 +54,13 @@ Using the  **FilePageSetupCalendar** method without specifying any arguments dis
 
 ## Example
 
-The following example sets up the calandar for printing with 2 months per page and with preview calendars for the previous and next months.
+The following example sets up the calendar for printing with 2 months per page and with preview calendars for the previous and next months.
 
 
 ```vb
 Sub File_PageSetupCalendar() 
  
- 'Activate Calandar view 
+ 'Activate Calendar view 
  ViewApply Name:="&Calendar" 
  FilePageSetupCalendar MonthsPerPage:=2, OnlyDaysInMonth:=False, MonthPreviews:=True 
 End Sub

--- a/api/Project.Application.FilePageSetupCalendarText.md
+++ b/api/Project.Application.FilePageSetupCalendarText.md
@@ -62,7 +62,7 @@ The following example formats monthly titles in red for printing.
 ```vb
 Sub File_PageSetupCalendarText() 
  
- 'Activate the Calandar view. 
+ 'Activate the Calendar view. 
  ViewApply Name:="&Calendar" 
  FilePageSetupCalendarText Item:=pjMonthlyTitles, Color:=pjRed 
  FilePrint 

--- a/api/Project.Application.FilePageSetupCalendarTextEx.md
+++ b/api/Project.Application.FilePageSetupCalendarTextEx.md
@@ -60,7 +60,7 @@ The following example formats monthly titles in red for printing.
 ```vb
 Sub File_PageSetupCalendarText() 
  
-    'Activate the Calandar view. 
+    'Activate the Calendar view. 
     ViewApply Name:="&Calendar" 
  
     FilePageSetupCalendarTextEx Item:=pjMonthlyTitles, Color:=&0101FF 

--- a/api/Project.Application.MakeLocalCalendarEnterprise.md
+++ b/api/Project.Application.MakeLocalCalendarEnterprise.md
@@ -30,8 +30,8 @@ Converts a local calendar to an enterprise calendar.
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _OldName_|Optional|**String**|Name of the local calander.|
-| _NewName_|Optional|**String**|Name of the Enterprise calander.|
+| _OldName_|Optional|**String**|Name of the local calendar.|
+| _NewName_|Optional|**String**|Name of the Enterprise calendar.|
 
 ## Return value
 

--- a/api/Project.Application.SetField.md
+++ b/api/Project.Application.SetField.md
@@ -43,7 +43,7 @@ Sets the value of a local custom field or enterprise custom field for the select
 
 If the custom field uses a lookup table that does not allow additional items to be entered, the specified Value must match a predefined value in the lookup table.
 
-If the value of the Field argument does not exist as a custom field name for the seleted items, the  **SetField** method results in run-time error 1101.
+If the value of the Field argument does not exist as a custom field name for the selected items, the  **SetField** method results in run-time error 1101.
 
 
 ## Example

--- a/api/Project.Application.SynchronizeWithSite.md
+++ b/api/Project.Application.SynchronizeWithSite.md
@@ -40,7 +40,7 @@ Synchronizes a local project in Project Professional with a SharePoint 2013 task
 
 ## Remarks
 
-The  **SynchronizeWithSite** method is available in Project Professional only, for a local project or for a SharePoint tasks list project that is stored in Project Web App. Saving a local project to a SharePoint site is a way to share some project details with people who do not have access to Project Web App. The SharePoint tasks list also enables users who have the correct permission to add tasks, assign tasks to resources, set task priority (low, normal, or high), set task status and percent complete, and set task precedessors.
+The  **SynchronizeWithSite** method is available in Project Professional only, for a local project or for a SharePoint tasks list project that is stored in Project Web App. Saving a local project to a SharePoint site is a way to share some project details with people who do not have access to Project Web App. The SharePoint tasks list also enables users who have the correct permission to add tasks, assign tasks to resources, set task priority (low, normal, or high), set task status and percent complete, and set task predecessors.
 
 For a tasks list project that SharePoint manages, when you use Project Professional to open that project from Project Web App, you can synchronize changes with the SharePoint tasks list manually in the Backstage view, or programmatically by using the  **SynchronizeWithSite** method.
 
@@ -66,7 +66,7 @@ Sub CreateSharePointTasksList()
 End Sub
 ```
 
-After you create a tasks list, it is not necessary to specifiy the SiteURL or ListName arguments again to synchronize the project with the same tasks list.
+After you create a tasks list, it is not necessary to specify the SiteURL or ListName arguments again to synchronize the project with the same tasks list.
 
 
 

--- a/api/Project.Application.TaskMoveToStatusDate.md
+++ b/api/Project.Application.TaskMoveToStatusDate.md
@@ -31,7 +31,7 @@ Moves completed or incomplete parts of one or more selected tasks to the status 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
 | _MoveCompleted_|Optional|**Boolean**|**True** if the completed parts of tasks are moved to the status date; otherwise, **False**. The default is **False**.|
-| _MoveIncomplete_|Optional|**Boolean**|**True** if the incomple parts of tasks are moved to the status date; otherwise, **False**. The default is **True**.|
+| _MoveIncomplete_|Optional|**Boolean**|**True** if the incomplete parts of tasks are moved to the status date; otherwise, **False**. The default is **True**.|
 
 ## Return value
 

--- a/api/Project.Application.TextStylesEx.md
+++ b/api/Project.Application.TextStylesEx.md
@@ -127,6 +127,6 @@ _expression_ A variable that represents an **Application** object.
 
 Using the **TextStylesEx** method without specifying any arguments displays the **Text Styles** dialog box.
 
-To set the text style by using hexadicimal RGB values, see the **[TextStyles32Ex](Project.Application.TextStyles32Ex.md)** method.
+To set the text style by using hexadecimal RGB values, see the **[TextStyles32Ex](Project.Application.TextStyles32Ex.md)** method.
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Project.Pane.View.md
+++ b/api/Project.Pane.View.md
@@ -28,7 +28,7 @@ Returns the active  **View** object.
 
 ## Example
 
-The following statement prints the name of the view in the  **Immediate** window in the VBE. For example, if the Team Planner view is active, the statement prints "Team Plannner".
+The following statement prints the name of the view in the  **Immediate** window in the VBE. For example, if the Team Planner view is active, the statement prints "Team Planner".
 
 
 ```vb

--- a/api/Project.PjCalendarType.md
+++ b/api/Project.PjCalendarType.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 
 # PjCalendarType Enumeration (Project)
 
-Contains constants that specify the type of calandar.
+Contains constants that specify the type of calendar.
 
 
 

--- a/api/Project.PjCustomFieldAttribute.md
+++ b/api/Project.PjCustomFieldAttribute.md
@@ -17,7 +17,7 @@ Contains constants that specify a field attribute.
 
 |Name|Value|Description|
 |:-----|:-----|:-----|
-|**pjFieldAttributeFormula**|1|Foumula.|
+|**pjFieldAttributeFormula**|1|Formula.|
 |**pjFieldAttributeNone**|0|None.|
 |**pjFieldAttributeValueList**|2|Value list.|
 

--- a/api/Project.PjFieldType.md
+++ b/api/Project.PjFieldType.md
@@ -18,7 +18,7 @@ Contains constants that specify the type of entity for a field.
 |Name|Value|Description|
 |:-----|:-----|:-----|
 |**pjProject**|2|Project entity.|
-|**pjResource**|1|Resouce entity.|
+|**pjResource**|1|Resource entity.|
 |**pjTask**|0|Task entity.|
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Project.PjGanttBarLink.md
+++ b/api/Project.PjGanttBarLink.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 
 # PjGanttBarLink Enumeration (Project)
 
-Contains constants that specify the type of Gnatt bar links.
+Contains constants that specify the type of Gantt bar links.
 
 
 

--- a/api/Project.PjIndicator.md
+++ b/api/Project.PjIndicator.md
@@ -44,7 +44,7 @@ Contains constants that specify a graphical indicator.
 |**pjIndicatorFaceStraightYellow**|61|The indicator is a yellow-colored straight face.|
 |**pjIndicatorFlagAqua**|18|The indicator is an aqua flag.|
 |**pjIndicatorFlagBlue**|19|The indicator is a blue flag.|
-|**pjIndicatorFlagFuschia**|20|The indicator is a fuschia flag.|
+|**pjIndicatorFlagFuchsia**|20|The indicator is a fuchsia flag.|
 |**pjIndicatorFlagLime**|14|The indicator is a lime flag.|
 |**pjIndicatorFlagRed**|16|The indicator is a red flag.|
 |**pjIndicatorFlagSilver**|21|The indicator is a silver flag.|
@@ -68,7 +68,7 @@ Contains constants that specify a graphical indicator.
 |**pjIndicatorSphereAqua**|6|The indicator is an aqua sphere.|
 |**pjIndicatorSphereBlack**|4|The indicator is a black sphere.|
 |**pjIndicatorSphereBlue**|8|The indicator is a blue sphere.|
-|**pjIndicatorSphereFuschia**|9|The indicator is a fuschia sphere.|
+|**pjIndicatorSphereFuchsia**|9|The indicator is a fuchsia sphere.|
 |**pjIndicatorSphereGray**|12|The indicator is a gray sphere.|
 |**pjIndicatorSphereGreen**|7|The indicator is a green sphere.|
 |**pjIndicatorSphereLime**|1|The indicator is a lime sphere.|

--- a/api/Project.PjResSubstitutionPoolOption.md
+++ b/api/Project.PjResSubstitutionPoolOption.md
@@ -19,6 +19,6 @@ Contains constants that specify the resource pooling option.
 |:-----|:-----|:-----|
 |**pjResSubstitutionResInList**|2|Use resources specified in the list of resources in the  **EnterpriseResSubstitutionWizard** method.|
 |**pjResSubstitutionResInProject**|0|Use resources already specified in the project.|
-|**pjResSubstitutionResInRBS**|1|Use resources in the resouce breakdown structure (RBS) level specified in the  **EnterpriseResSubstitutionWizard** method.|
+|**pjResSubstitutionResInRBS**|1|Use resources in the resource breakdown structure (RBS) level specified in the  **EnterpriseResSubstitutionWizard** method.|
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Project.PjStatusType.md
+++ b/api/Project.PjStatusType.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 
 # PjStatusType Enumeration (Project)
 
-Contains constants that specify the staus of a task.
+Contains constants that specify the status of a task.
 
 
 

--- a/api/Project.PjTaskTimescaledData.md
+++ b/api/Project.PjTaskTimescaledData.md
@@ -109,7 +109,7 @@ Contains constants that specify the type of field for task timescaled data in th
 |**pjTaskTimescaledCPI**|537|CPI (task) field.|
 |**pjTaskTimescaledCumulativeActualWork**|1341|Cumulative actual work (task) field.|
 |**pjTaskTimescaledCumulativeCost**|177|Cumulative Cost (task) field.|
-|**pjTaskTimescaledCumulativePercentComplete**|240|Cmulative Percent Complete (task) field.|
+|**pjTaskTimescaledCumulativePercentComplete**|240|Cumulative Percent Complete (task) field.|
 |**pjTaskTimescaledCumulativeWork**|176|Cumulative Work (task) field.|
 |**pjTaskTimescaledCV**|83|CV (task) field.|
 |**pjTaskTimescaledCVP**|539|CVP (task) field.|

--- a/api/Project.Project.CurrencyCode.md
+++ b/api/Project.Project.CurrencyCode.md
@@ -23,7 +23,7 @@ Project property for the three-character ISO standard currency code of the proje
 
 ## Example
 
-The follwoing example sets  **CurrencyCode** to the three-character ISO currency code "JPY".
+The following example sets  **CurrencyCode** to the three-character ISO currency code "JPY".
 
 
 ```vb

--- a/api/Project.Project.DeliverableUpdate.md
+++ b/api/Project.Project.DeliverableUpdate.md
@@ -27,7 +27,7 @@ Updates the properties of a deliverable.
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _DeliverableGuid_|Required|**String**|GUID of the deliberable to update.|
+| _DeliverableGuid_|Required|**String**|GUID of the deliverable to update.|
 | _DeliverableName_|Required|**String**|Name of the deliverable.|
 | _DeliverableStartDate_|Required|**Variant**|Date when the deliverable starts.|
 | _DeliverableFinishDate_|Required|**Variant**|Date when the deliverable is finished.|

--- a/api/Project.Project.PhoneticType.md
+++ b/api/Project.Project.PhoneticType.md
@@ -26,6 +26,6 @@ Gets or sets the type of characters used to display phonetic information. Read/w
 
 ## Remarks
 
-The  **PhoneticType** property can be one of the following **[PjPhoneticType](Project.PjPhoneticType.md)** constants: **pjKatakanaHalf**, **pjKatakana**, or **pjHiragana**. The **PhoneticType** property produces tangible results only if the Japanese version of Projectis used.
+The  **PhoneticType** property can be one of the following **[PjPhoneticType](Project.PjPhoneticType.md)** constants: **pjKatakanaHalf**, **pjKatakana**, or **pjHiragana**. The **PhoneticType** property produces tangible results only if the Japanese version of Project is used.
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Project.Task.LinkSuccessors.md
+++ b/api/Project.Task.LinkSuccessors.md
@@ -43,7 +43,7 @@ The following example create two tasks and links the second task as successor to
 
 ```vb
 Sub Link_Successors() 
-    Dim SucessorTask As Task 
+    Dim SuccessorTask As Task 
     Dim PredecessorTask As Task 
  
     'Activate Task Sheet view 
@@ -60,13 +60,13 @@ Sub Link_Successors()
  
     'link them 
     Set PredecessorTask = ActiveProject.Tasks("TestTask-1") 
-    Set SucessorTask = ActiveProject.Tasks("TestTask-2") 
+    Set SuccessorTask = ActiveProject.Tasks("TestTask-2") 
  
-    PredecessorTask.LinkSuccessors Tasks:=SucessorTask, Link:=pjFinishToStart 
+    PredecessorTask.LinkSuccessors Tasks:=SuccessorTask, Link:=pjFinishToStart 
  
     'delete the tasks 
     PredecessorTask.Delete 
-    SucessorTask.Delete 
+    SuccessorTask.Delete 
 End Sub
 ```
 

--- a/api/Project.shape.vertices.md
+++ b/api/Project.shape.vertices.md
@@ -8,7 +8,7 @@ localization_priority: Normal
 
 
 # Shape.Vertices Property (Project)
-Gets the coordinates of the vertices (and control points for a B?zier curve) as a series of coordinate pairs, for a shape that is a drawing. Read-only  **Variant**.
+Gets the coordinates of the vertices (and control points for a Bézier curve) as a series of coordinate pairs, for a shape that is a drawing. Read-only  **Variant**.
 
 ## Syntax
 

--- a/api/Project.shaperange.vertices.md
+++ b/api/Project.shaperange.vertices.md
@@ -8,7 +8,7 @@ localization_priority: Normal
 
 
 # ShapeRange.Vertices Property (Project)
-Gets the coordinates of the vertices (and control points for a B?zier curve) as a series of coordinate pairs, for a shape range that contains a drawing. Read-only  **Variant**.
+Gets the coordinates of the vertices (and control points for a Bézier curve) as a series of coordinate pairs, for a shape range that contains a drawing. Read-only  **Variant**.
 
 ## Syntax
 

--- a/api/Project.shapes.addcurve.md
+++ b/api/Project.shapes.addcurve.md
@@ -8,7 +8,7 @@ localization_priority: Normal
 
 
 # Shapes.AddCurve Method (Project)
-Adds a B?zier curve to a report, and returns a  **Shape** object that represents the curve.
+Adds a Bézier curve to a report, and returns a  **Shape** object that represents the curve.
 
 ## Syntax
 
@@ -33,7 +33,7 @@ Adds a B?zier curve to a report, and returns a  **Shape** object that represents
 
 ## Remarks
 
-For the  _SafeArrayOfPoints_ parameter, the first point you specify is the starting vertex, and the next two points are control points for the first B?zier segment. Then, for each additional segment of the curve, you specify a vertex and two control points. The last point you specify is the ending vertex for the curve. Note that you must always specify 3 _n_ + 1 points, where _n_ is the number of segments in the curve.
+For the  _SafeArrayOfPoints_ parameter, the first point you specify is the starting vertex, and the next two points are control points for the first Bézier segment. Then, for each additional segment of the curve, you specify a vertex and two control points. The last point you specify is the ending vertex for the curve. Note that you must always specify 3 _n_ + 1 points, where _n_ is the number of segments in the curve.
 
 
 ## Example

--- a/api/Publisher.Application.MailMergeInsertBarcode.md
+++ b/api/Publisher.Application.MailMergeInsertBarcode.md
@@ -37,7 +37,7 @@ Occurs when the user issues the command to insert postal barcodes into a mail-me
 
 You can use the  **[InsertBarcode](Publisher.TextRange.InsertBarcode.md)** method to insert barcodes into a mail merge publication.
 
-Third-party add-ins that validate mail-merge addresses can use the  **MailMergeInsertBarcode** event to listen for user actions requesting that barcodes be inserted. In this situation, when the add-in receives notification that the **MailMergeInsertBarcode** event fired, it checks the validity of the addresses in the mail-merge list, and if the addreses are valid, it attempts to generate barcodes. If this attempt is successful, the add-in should return **True** for the OkToInsert parameter. If the attempt fails, the add-in should return **False**.
+Third-party add-ins that validate mail-merge addresses can use the  **MailMergeInsertBarcode** event to listen for user actions requesting that barcodes be inserted. In this situation, when the add-in receives notification that the **MailMergeInsertBarcode** event fired, it checks the validity of the addresses in the mail-merge list, and if the addresses are valid, it attempts to generate barcodes. If this attempt is successful, the add-in should return **True** for the OkToInsert parameter. If the attempt fails, the add-in should return **False**.
 
 Actual barcode data is provided to Publisher by the  **[MailMergeGenerateBarcode](Publisher.Application.MailMergeGenerateBarcode.md)** event.
 

--- a/api/Publisher.Application.MillimetersToPoints.md
+++ b/api/Publisher.Application.MillimetersToPoints.md
@@ -63,7 +63,7 @@ Do While True
  ' Evaluate and display result. 
  strOutput = Trim(strInput) & " mm = " _ 
  & Format(Application _ 
- .Mill imetersToPoints(Value:=Val(strInput)), _ 
+ .MillimetersToPoints(Value:=Val(strInput)), _ 
  "0.00") & " points" 
  
  MsgBox strOutput 

--- a/api/Publisher.CatalogMergeShapes.md
+++ b/api/Publisher.CatalogMergeShapes.md
@@ -28,7 +28,7 @@ Shapes inside the catalog merge area are automatically resized or repositioned i
  
 
  
-The catalog merge area can contain picture and text data fields you have inserted, in addtion to other design elements you choose. 
+The catalog merge area can contain picture and text data fields you have inserted, in addition to other design elements you choose. 
  
 
  

--- a/api/Publisher.Document.ChangeDocument.md
+++ b/api/Publisher.Document.ChangeDocument.md
@@ -40,7 +40,7 @@ Possible values for the Wizard parameter are declared in the  **[PbWizard](Publi
 
 ## Example
 
-The following Microsoft Visual Basic for Applications (VBA) macro shows how to use the  **ChangeDocument** method to change the wizard used by the current publicaton to a brochure.
+The following Microsoft Visual Basic for Applications (VBA) macro shows how to use the  **ChangeDocument** method to change the wizard used by the current publication to a brochure.
 
 
 ```vb

--- a/api/Publisher.Document.SetBusinessInformation.md
+++ b/api/Publisher.Document.SetBusinessInformation.md
@@ -34,7 +34,7 @@ Applies the specified business information set, which consists of a logo image a
 
 ## Remarks
 
-Calling the  **SetBusinessInformation** method corresponds to selecting a business information set (in the **Select a Business Information set** list) and then clicking the **Update Publication** button in the **Business Information** dialog box (**Edit** menu) in the Microsoft Publisher user interface (UI). You must create and edit business information sets in that dialog box before you can use the **SetBusinessInformation** method to apply them programatically.
+Calling the  **SetBusinessInformation** method corresponds to selecting a business information set (in the **Select a Business Information set** list) and then clicking the **Update Publication** button in the **Business Information** dialog box (**Edit** menu) in the Microsoft Publisher user interface (UI). You must create and edit business information sets in that dialog box before you can use the **SetBusinessInformation** method to apply them programmatically.
 
 
 ## Example

--- a/api/Publisher.FillFormat.Visible.md
+++ b/api/Publisher.FillFormat.Visible.md
@@ -34,7 +34,7 @@ The  **Visible** property value can be one of the **MsoTriState** constants decl
 |:-----|:-----|
 | **msoFalse**|The specified object or formatting is not visible.|
 | **msoTriStateMixed**|Return value only. The specified shape range contains both objects with visible formatting and objects with invisible formatting.|
-| **msoTriStateToggle**| Set value only. Switches the specified object between visible and invisble.|
+| **msoTriStateToggle**| Set value only. Switches the specified object between visible and invisible.|
 | **msoTrue**|The specified object or formatting is visible.|
 
 ## Example

--- a/api/Publisher.LineFormat.Visible.md
+++ b/api/Publisher.LineFormat.Visible.md
@@ -34,7 +34,7 @@ The  **Visible** property value can be one of the **MsoTriState** constants decl
 |:-----|:-----|
 | **msoFalse**|The specified object or formatting is not visible.|
 | **msoTriStateMixed**|Return value only. The specified shape range contains both objects with visible formatting and objects with invisible formatting.|
-| **msoTriStateToggle**| Set value only. Switches the specified object between visible and invisble.|
+| **msoTriStateToggle**| Set value only. Switches the specified object between visible and invisible.|
 | **msoTrue**|The specified object or formatting is visible.|
 
 ## Example

--- a/api/Publisher.Page.md
+++ b/api/Publisher.Page.md
@@ -31,7 +31,7 @@ Sub AddPageNumberField()
 End Sub
 ```
 
-Use the  **[FindBypageID](./Publisher.Pages.FindByPageID.md)** property to locate a **Page** object using the application assigned page ID. Use the **[Add](./Publisher.Pages.Add.md)** method to create a new page and add it to the publication. The following example adds a new page to the active publication and then looks for that page using the page ID.
+Use the  **[FindByPageID](./Publisher.Pages.FindByPageID.md)** property to locate a **Page** object using the application assigned page ID. Use the **[Add](./Publisher.Pages.Add.md)** method to create a new page and add it to the publication. The following example adds a new page to the active publication and then looks for that page using the page ID.
 
 
 

--- a/api/Publisher.PbPageNumberFormat.md
+++ b/api/Publisher.PbPageNumberFormat.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # PbPageNumberFormat Enumeration (Publisher)
 
-Reperesents the formatting of the page numbering.
+Represents the formatting of the page numbering.
 
 
 

--- a/api/Publisher.PbTabAlignmentType.md
+++ b/api/Publisher.PbTabAlignmentType.md
@@ -20,7 +20,7 @@ Represents the alignment for the specified tab stop.
 
 |Name|Value|Description|
 |:-----|:-----|:-----|
-| **pbTabAlignmentCenter**|1|Centeral tab alignment|
+| **pbTabAlignmentCenter**|1|Central tab alignment|
 | **pbTabAlignmentDecimal**|3|Decimal tab alignment|
 | **pbTabAlignmentLeading**|0|Leading tab alignment|
 | **pbTabAlignmentTrailing**|2|Trailing tab alignment|

--- a/api/Publisher.PbTextDirection.md
+++ b/api/Publisher.PbTextDirection.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # PbTextDirection Enumeration (Publisher)
 
-Indicats the direction in which text flows in the specified paragraph.
+Indicates the direction in which text flows in the specified paragraph.
 
 
 

--- a/api/Publisher.Plate.Delete.md
+++ b/api/Publisher.Plate.Delete.md
@@ -45,7 +45,7 @@ The ReplaceTint parameter can be one of the following  **pbReplaceTint** constan
 | **pbReplaceTintMaintainLuminosity**| Maintain the same lightness value in the ink represented by the replacement plate as in the deleted plate. For example, replace a 100% tint of yellow with an approximately 10% tint of blue.|
 | **pbReplaceTintUseDefault**|Use the default. |
 
-If the  **pbReplaceTintMaintainLuminosity** constant is specified, the percentage of replacment ink in each color is calculated based on the luminosity values of the inks represented by the deleted and replacement plates. Publisher performs the following calculation, where _L1_ is the deleted ink luminosity, and _L2_ is the replacement ink luminosity: (100- _L1_)/(100- _L2_).
+If the  **pbReplaceTintMaintainLuminosity** constant is specified, the percentage of replacement ink in each color is calculated based on the luminosity values of the inks represented by the deleted and replacement plates. Publisher performs the following calculation, where _L1_ is the deleted ink luminosity, and _L2_ is the replacement ink luminosity: (100- _L1_)/(100- _L2_).
 
 For example, red ink has a luminosity of 30, and black has a luminosity of 0. Suppose you replaced the red ink plate in a publication with a black ink plate. If  **pbReplaceTintKeepTints** is specified, Publisher performs the following calculation to determine the percentage of black ink for each red color: (100-30)/(100-0). A color that was 100% red would now be 70% black; a color that was 50% red would now be 35% black, and so on.
 

--- a/api/Publisher.Section.ContinueNumbersFromPreviousSection.md
+++ b/api/Publisher.Section.ContinueNumbersFromPreviousSection.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Section.ContinueNumbersFromPreviousSection Property (Publisher)
 
- **True** if the specified section continues the numbering from the prvious section. Read/write **Boolean**.
+ **True** if the specified section continues the numbering from the previous section. Read/write **Boolean**.
 
 
 ## Syntax

--- a/api/Publisher.Section.PageNumberFormat.md
+++ b/api/Publisher.Section.PageNumberFormat.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Section.PageNumberFormat Property (Publisher)
 
-Sets or returns a  **PbPageNumberFormat** constant that reperesents the formatting of the page numbering. Read/write.
+Sets or returns a  **PbPageNumberFormat** constant that represents the formatting of the page numbering. Read/write.
 
 
 ## Syntax

--- a/api/Publisher.Sections.md
+++ b/api/Publisher.Sections.md
@@ -54,7 +54,7 @@ Use  **Sections**.Count to return the number of sections in the publication. The
 MsgBox Documents(1).Sections.Count
 ```
 
-Use  **Sections**.Add(StartPageIndex) where StartPageIndex is the index number of the page, to reutrn a new section added to a document. A "Permission denied." error will be returned if the page already contains a section head. The following example adds a new section to the second page of the active document.
+Use  **Sections**.Add(StartPageIndex) where StartPageIndex is the index number of the page, to return a new section added to a document. A "Permission denied." error will be returned if the page already contains a section head. The following example adds a new section to the second page of the active document.
  
 
  

--- a/api/Publisher.Selection.md
+++ b/api/Publisher.Selection.md
@@ -31,7 +31,7 @@ Sub CopySelection()
 End Sub
 ```
 
-The following example determines what type of item is selected and, if it is an autoshape, fills the first shape in the selection with color. This example assumes there is at least one item selected in the active pubication.
+The following example determines what type of item is selected and, if it is an autoshape, fills the first shape in the selection with color. This example assumes there is at least one item selected in the active publication.
  
 
  

--- a/api/Publisher.ShadowFormat.Visible.md
+++ b/api/Publisher.ShadowFormat.Visible.md
@@ -34,7 +34,7 @@ The  **Visible** property value can be one of the **MsoTriState** constants decl
 |:-----|:-----|
 | **msoFalse**|The specified object or formatting is not visible.|
 | **msoTriStateMixed**|Return value only. The specified shape range contains both objects with visible formatting and objects with invisible formatting.|
-| **msoTriStateToggle**| Set value only. Switches the specified object between visible and invisble.|
+| **msoTriStateToggle**| Set value only. Switches the specified object between visible and invisible.|
 | **msoTrue**|The specified object or formatting is visible.|
 
 ## Example

--- a/api/Publisher.ShapeRange.md
+++ b/api/Publisher.ShapeRange.md
@@ -76,7 +76,7 @@ Use the  **[Align](./Publisher.ShapeRange.Align.md)**, **[Distribute](./Publishe
 
 
 ```vb
-Sub AlignDistibuteShapes() 
+Sub AlignDistributeShapes() 
     Dim rngShapes As ShapeRange 
     Set rngShapes = ActiveDocument.Pages(1).Shapes.Range 
  

--- a/api/Publisher.ThreeDFormat.PresetLightingSoftness.md
+++ b/api/Publisher.ThreeDFormat.PresetLightingSoftness.md
@@ -40,7 +40,7 @@ This example sets the extrusion for the first shape on the first page of the act
 
 
 ```vb
-Sub SetExtrusionLightingBrighness() 
+Sub SetExtrusionLightingBrightness() 
  With ActiveDocument.Pages(1).Shapes(1).ThreeD 
  .Visible = True 
  .PresetLightingSoftness = msoLightingBright 

--- a/api/Publisher.ThreeDFormat.Visible.md
+++ b/api/Publisher.ThreeDFormat.Visible.md
@@ -34,7 +34,7 @@ The  **Visible** property value can be one of the **MsoTriState** constants decl
 |:-----|:-----|
 | **msoFalse**|The specified object or formatting is not visible.|
 | **msoTriStateMixed**|Return value only. The specified shape range contains both objects with visible formatting and objects with invisible formatting.|
-| **msoTriStateToggle**| Set value only. Switches the specified object between visible and invisble.|
+| **msoTriStateToggle**| Set value only. Switches the specified object between visible and invisible.|
 | **msoTrue**|The specified object or formatting is visible.|
 
 ## Example

--- a/api/Publisher.WebNavigationBarSets.md
+++ b/api/Publisher.WebNavigationBarSets.md
@@ -85,7 +85,7 @@ MsgBox ActiveDocument.WebNavigationBarSets.Count
 
 ```
 
-Use  **WebNavigationBarSets** **.AddToEveryPage** (Left, Top, [Width]), where Left is the distance from the left of the page to the left edge of the navigation bar, Top is the distance form the top of the page to the top edge of the navigation bar, and Width is the width of the navigaion bar, to add the specified navigation bar to every page. The following example adds the navigation bar named "WebNavBar1" to every page in the current publication.
+Use  **WebNavigationBarSets** **.AddToEveryPage** (Left, Top, [Width]), where Left is the distance from the left of the page to the left edge of the navigation bar, Top is the distance form the top of the page to the top edge of the navigation bar, and Width is the width of the navigation bar, to add the specified navigation bar to every page. The following example adds the navigation bar named "WebNavBar1" to every page in the current publication.
  
 
  

--- a/api/Visio.Application.KeyDown.md
+++ b/api/Visio.Application.KeyDown.md
@@ -52,7 +52,7 @@ If you set  _CancelDefault_ to **True** , Visio does not process the message rec
 Unlike some other Visio events,  **KeyDown** does not have the prefix "Query," but it is still a query event. That is, you can cancel processing the message sent by **KeyDown** , either by setting _CancelDefault_ to **True** , or, if you are using the **VisEventProc** method to handle the event, by returning **True**. For more information, see the topics for the **VisEventProc** method and for any of the query events (for example, the **QueryCancelSuspend** event) in this Automation Reference.
 
 
- **Note**  Pressing an accelererator key combination, for example, CTRL + C, does not fire the  **KeyDown** event.
+ **Note**  Pressing an accelerator key combination, for example, CTRL + C, does not fire the  **KeyDown** event.
 
 If you are using VBA, the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.Application.KeyPress.md
+++ b/api/Visio.Application.KeyPress.md
@@ -39,7 +39,7 @@ If you set  _CancelDefault_ to **True** , Visio does not process the message rec
 Unlike some other Visio events,  **KeyPress** does not have the prefix "Query," but it is still a query event. That is, you can cancel processing the message sent by **KeyPress** , either by setting _CancelDefault_ to **True** , or, if you are using the **VisEventProc** method to handle the event, by returning **True**. For more information, see the topics for the **VisEventProc** method and for any of the query events (for example, the **QueryCancelSuspend** event) in this Automation Reference.
 
 
- **Note**  Pressing an accelererator key combination, for example, CTRL + C, does not fire the  **KeyPress** event.
+ **Note**  Pressing an accelerator key combination, for example, CTRL + C, does not fire the  **KeyPress** event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.Application.QueryCancelUngroup.md
+++ b/api/Visio.Application.QueryCancelUngroup.md
@@ -42,7 +42,7 @@ A Microsoft Visio instance fires  **QueryCancelUngroup** after the user has dire
     
 
 
-While a Visio instance is firing a query or cancel event, it respondsto inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
+While a Visio instance is firing a query or cancel event, it responds to inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.Application.RegisterRibbonX.md
+++ b/api/Visio.Application.RegisterRibbonX.md
@@ -30,7 +30,7 @@ Registers the  **[IRibbonExtensibility](Office.IRibbonExtensibility.md)** interf
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _SourceAddOn_|Required| **IRibbonExtensibilty**|The add-on to register.|
+| _SourceAddOn_|Required| **IRibbonExtensibility**|The add-on to register.|
 | _TargetDocument_|Required| **[Document](Visio.Document.md)**|The document that uses the custom UI.|
 | _TargetModes_|Required| **[VisRibbonXModes](Visio.VisRibbonXModes.md)**|The modes in which the custom UI should be visible. See Remarks for possible values.|
 | _FriendlyName_|Required| **String**|The name to associate with the UI items and errors that originate in the add-on.|

--- a/api/Visio.Application.UnregisterRibbonX.md
+++ b/api/Visio.Application.UnregisterRibbonX.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Application.UnregisterRibbonX Method (Visio)
 
-Unregisters a previouly registered  **IRibbonExtensiblity** interface that a Microsoft Visio add-in implements.
+Unregisters a previously registered  **IRibbonExtensibility** interface that a Microsoft Visio add-in implements.
 
 
 ## Syntax

--- a/api/Visio.ApplicationSettings.DefaultSaveFormat.md
+++ b/api/Visio.ApplicationSettings.DefaultSaveFormat.md
@@ -34,7 +34,7 @@ VisDefaultSaveFormats
 Setting the  **DefaultSaveFormat** property is equivalent to setting the **Save files in this format** option on the **Save** tab in the **Visio Options** dialog box (click the **File** tab, click **Options**, and then click  **Save**).
 
 
- **Note**  The  **DefaultSaveFormat** property setting has no effect on the file type in which Visio files are saved by the **Save** or **SaveAs** methods of the **Document** object. To control the file type in which a document is saved programatically, use the **Version** property of the **Document** object.
+ **Note**  The  **DefaultSaveFormat** property setting has no effect on the file type in which Visio files are saved by the **Save** or **SaveAs** methods of the **Document** object. To control the file type in which a document is saved programmatically, use the **Version** property of the **Document** object.
 
 The following  **VisDefaultSaveFormats** constants, which are declared in the Visio type library, show the possible values for the **DefaultSaveFormat** property.
 

--- a/api/Visio.ApplicationSettings.EnableAutoConnect.md
+++ b/api/Visio.ApplicationSettings.EnableAutoConnect.md
@@ -31,6 +31,6 @@ Boolean
 
 ## Remarks
 
-The  **EnableAutoConnect** property lets you disable programmtically the Visio **AutoConnect** feature, which is on by default. The setting of the **EnableAutoConnect** property corresponds to the **Enable AutoConnect** setting on the **Advanced** tab of the **Visio Options** dialog box (click the **File** tab, and then click **Options**).
+The  **EnableAutoConnect** property lets you disable programmatically the Visio **AutoConnect** feature, which is on by default. The setting of the **EnableAutoConnect** property corresponds to the **Enable AutoConnect** setting on the **Advanced** tab of the **Visio Options** dialog box (click the **File** tab, and then click **Options**).
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Visio.Characters.AddField.md
+++ b/api/Visio.Characters.AddField.md
@@ -58,7 +58,7 @@ Using the  **AddField** method is similar to clicking **Field** on the **Insert*
 
 To add a custom formula field, use the  **AddCustomField** method.
 
-To specify language and calendary versions for Date/Time fields, use the  **AddFieldEx** method.
+To specify language and calendar versions for Date/Time fields, use the  **AddFieldEx** method.
 
 Constant values for  _Category_,  _Code_, and  _Format_ are declared by the Visio type library in **[VisFieldCategories](Visio.visfieldcategories.md)** , **[VisFieldCodes](Visio.visfieldcodes.md)** , and **[VisFieldFormats](Visio.visfieldformats.md)** respectively.
 

--- a/api/Visio.ContainerProperties.ReorderListMember.md
+++ b/api/Visio.ContainerProperties.ReorderListMember.md
@@ -50,7 +50,7 @@ To insert after the final item in the list, set  _Position_ greater than or equa
 
 If you pass an out-of-range value for  _Position_, Visio uses the nearest valid position.
 
-If you pass a non-contiguous selection of list members for  _ObjectToReorder_, Visio makes the selection contiguous in the resulting reordered list, while maintaining relative position. For example, in a list ordered A,B,C,D, if you move B and D to position 1, the resutling list order is B,D,A,C.
+If you pass a non-contiguous selection of list members for  _ObjectToReorder_, Visio makes the selection contiguous in the resulting reordered list, while maintaining relative position. For example, in a list ordered A,B,C,D, if you move B and D to position 1, the resulting list order is B,D,A,C.
 
 
 ## Example

--- a/api/Visio.DataRecordset.Refresh.md
+++ b/api/Visio.DataRecordset.Refresh.md
@@ -34,7 +34,7 @@ Nothing
 
 ## Remarks
 
-Calling the  **Refresh** method on a particular **DataRecordset** object results in refreshing all other **DataRecordset** objects associated with the same **[DataConnection](Visio.DataConnection.md)** object (that is, having the same value for their **[DataConnection](Visio.DataRecordset.DataConnection.md)** property). **DataRecordset** objects sharing the same **DataConnection** property value are called _transacted_ data recordsets. The **Refresh** method must be called on a data recordset that is associated with a **DataConnection** objecct.
+Calling the  **Refresh** method on a particular **DataRecordset** object results in refreshing all other **DataRecordset** objects associated with the same **[DataConnection](Visio.DataConnection.md)** object (that is, having the same value for their **[DataConnection](Visio.DataRecordset.DataConnection.md)** property). **DataRecordset** objects sharing the same **DataConnection** property value are called _transacted_ data recordsets. The **Refresh** method must be called on a data recordset that is associated with a **DataConnection** object.
 
 If you call  **Refresh** on a data recordset not associated with a **DataConnection** object (one that was created by using the **[DataRecordsets.AddFromXML](Visio.DataRecordsets.AddFromXML.md)** method), the **Refresh** method will return an error.
 

--- a/api/Visio.DataRecordsets.Add.md
+++ b/api/Visio.DataRecordsets.Add.md
@@ -86,7 +86,7 @@ If the  **Add** method succeeds, it performs the following actions:
 Unless you pass  **visDataRecordsetDelayQuery** as part of the AddOptions parameter, the **Add** method also does the following:
 
 
-- Executes the query string specified in the CommandString parameter and retreive the resulting data.
+- Executes the query string specified in the CommandString parameter and retrieve the resulting data.
     
 - Maps the data types of the columns of the data source to equivalent Visio data types, while filtering the results to remove data-source columns that cannot be linked to Visio shapes because they have no equivalent Visio data type. In particular, you cannot import binary data or esoteric data types such as  **UserDefined** , **Chapter** , and **IDispatch**.
     

--- a/api/Visio.DataRecordsets.AddFromConnectionFile.md
+++ b/api/Visio.DataRecordsets.AddFromConnectionFile.md
@@ -71,7 +71,7 @@ If the  **AddFromConnectionFile** method succeeds, it performs the following act
     
 - Associates a new or existing  **DataConnection** object with the **DataRecordset** object.
     
-- Executes the query string specified in the command string within the ODC file and retreives the resulting data.
+- Executes the query string specified in the command string within the ODC file and retrieves the resulting data.
     
 - Maps the data types of the columns of the data source to equivalent Visio data types, while filtering the results to remove data-source columns that cannot be linked to Visio shapes because they have no equivalent Visio data type. 
     

--- a/api/Visio.DataRecordsets.GetLastDataError.md
+++ b/api/Visio.DataRecordsets.GetLastDataError.md
@@ -52,7 +52,7 @@ If attempting to add a data recordset generates an error, the method returns Rec
 
 If attempting to refresh the data in an existing data recordset causes an error, and if Visio knows which data recordset caused the error,  **GetLastDataError** returns the ID of the data recordset.
 
-It is possible, however, that Visio may not know specifically which data recordset generated the error. This can only happen when you attempt to refresh a data recordset that is one of a group of data recordsets that share the same connection to a data source. This is because when data in one data recordset in such a group (called  _transacted_ datarecordsets) is refreshed, all the data recordsets in the group are refreshed. In this situation, if the refresh operation fails before all datarecordsets in the group are refreshed, Visio rolls back the refresh of any datarecordsets succesfulfully completed up to that point.
+It is possible, however, that Visio may not know specifically which data recordset generated the error. This can only happen when you attempt to refresh a data recordset that is one of a group of data recordsets that share the same connection to a data source. This is because when data in one data recordset in such a group (called  _transacted_ datarecordsets) is refreshed, all the data recordsets in the group are refreshed. In this situation, if the refresh operation fails before all datarecordsets in the group are refreshed, Visio rolls back the refresh of any datarecordsets successfully completed up to that point.
 
 If you then call  **GetLastDataError** , the method returns the following:
 

--- a/api/Visio.Document.MasterShortcuts.md
+++ b/api/Visio.Document.MasterShortcuts.md
@@ -35,7 +35,7 @@ This Microsoft Visual Basic for Applications (VBA) macro shows how to use the  *
 
 
 
-Before running this example, replace the reference to  _StencilWithShortucts.vss_ with a reference to a valid .vss file that contains master shortcuts.
+Before running this example, replace the reference to  _StencilWithShortcuts.vss_ with a reference to a valid .vss file that contains master shortcuts.
 
 
 ### To create a stencil that contains master shortcuts:

--- a/api/Visio.Document.QueryCancelUngroup.md
+++ b/api/Visio.Document.QueryCancelUngroup.md
@@ -45,7 +45,7 @@ A Microsoft Visio instance fires  **QueryCancelUngroup** after the user has dire
     
 
 
-While a Visio instance is firing a query or cancel event, it respondsto inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
+While a Visio instance is firing a query or cancel event, it responds to inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.Documents.QueryCancelUngroup.md
+++ b/api/Visio.Documents.QueryCancelUngroup.md
@@ -45,7 +45,7 @@ A Microsoft Visio instance fires  **QueryCancelUngroup** after the user has dire
     
 
 
-While a Visio instance is firing a query or cancel event, it respondsto inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
+While a Visio instance is firing a query or cancel event, it responds to inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.DrawingControl.KeyDown.md
+++ b/api/Visio.DrawingControl.KeyDown.md
@@ -52,7 +52,7 @@ If you set  _CancelDefault_ to **True** , Visio does not process the message rec
 Unlike some other Visio events,  **KeyDown** does not have the prefix "Query," but it is still a query event. That is, you can cancel processing the message sent by **KeyDown** , either by setting _CancelDefault_ to **True** , or, if you are using the **VisEventProc** method to handle the event, by returning **True**. For more information, see the topics for the **VisEventProc** method and for any of the query events (for example, the **QueryCancelSuspend** event) in this Automation Reference.
 
 > [!NOTE] 
-> Pressing an accelererator key combination, for example, CTRL + C, does not fire the  **KeyDown** event.
+> Pressing an accelerator key combination, for example, CTRL + C, does not fire the  **KeyDown** event.
 
 If you are using VBA, the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.DrawingControl.KeyPress.md
+++ b/api/Visio.DrawingControl.KeyPress.md
@@ -39,7 +39,7 @@ If you set  _CancelDefault_ to **True** , Visio does not process the message rec
 Unlike some other Visio events,  **KeyPress** does not have the prefix "Query," but it is still a query event. That is, you can cancel processing the message sent by **KeyPress** , either by setting _CancelDefault_ to **True** , or, if you are using the **VisEventProc** method to handle the event, by returning **True**. For more information, see the topics for the **VisEventProc** method and for any of the query events (for example, the **QueryCancelSuspend** event) in this Automation Reference.
 
 
- **Note**  Pressing an accelererator key combination, for example, CTRL + C, does not fire the  **KeyPress** event.
+ **Note**  Pressing an accelerator key combination, for example, CTRL + C, does not fire the  **KeyPress** event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.DrawingControl.QueryCancelUngroup.md
+++ b/api/Visio.DrawingControl.QueryCancelUngroup.md
@@ -42,7 +42,7 @@ A Microsoft Visio instance fires  **QueryCancelUngroup** after the user has dire
     
 
 
-While a Visio instance is firing a query or cancel event, it respondsto inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
+While a Visio instance is firing a query or cancel event, it responds to inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.GraphicItem.Index.md
+++ b/api/Visio.GraphicItem.Index.md
@@ -36,7 +36,7 @@ Long
 
 The index of a graphic item is originally determined by the order in which the item was added to the collection. The  **GraphicItems** collection is 1-based.
 
-The index order of graphic items affects the stacking order for multiple grpahic item callouts assigned to the same location. In addition, it determiones which graphic item takes precedence in control over a cell in the Microsoft Visio ShapeSheet spreadsheet when conflicting conditions set by multiple graphic items are all true .
+The index order of graphic items affects the stacking order for multiple graphic item callouts assigned to the same location. In addition, it determines which graphic item takes precedence in control over a cell in the Microsoft Visio ShapeSheet spreadsheet when conflicting conditions set by multiple graphic items are all true .
 
 
  **Note**  Before you can set any property of a graphic item, you must use the  **[Master.Open](Visio.Master.Open.md)** method to open a copy of the data graphic master that contains the graphic item for editing. When you are finished setting properties, use the **Master.Close** method to commit changes.

--- a/api/Visio.Hyperlink.ExtraInfo.md
+++ b/api/Visio.Hyperlink.ExtraInfo.md
@@ -35,10 +35,10 @@ Setting the  **ExtraInfo** property of a shape's **Hyperlink** object is optiona
 
 You might, for example, set the  **Hyperlink** object's **ExtraInfo** property to the coordinates of an image map, the contents of a form, or a file name.
 
-If the  **ExtraInfo** property you provide contains reserved characters other than spaces, you must input the escape character "%" and the character's hexidecimal equivalent. For example:
+If the  **ExtraInfo** property you provide contains reserved characters other than spaces, you must input the escape character "%" and the character's hexadecimal equivalent. For example:
 
 For "NAME=John Smith", set the  **ExtraInfo** property to "NAME=John Smith," because the extra information contains spaces, but no reserved characters.
 
-For "PATH= _driveletter_ :\ _foldename_ ", set the **ExtraInfo** property to "PATH= _driveletter_ %3A%5C _foldername_ ", because of the reserved characters.
+For "PATH= _driveletter_ :\ _foldername_ ", set the **ExtraInfo** property to "PATH= _driveletter_ %3A%5C _foldername_ ", because of the reserved characters.
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Visio.IVisEventProc.VisEventProc.md
+++ b/api/Visio.IVisEventProc.VisEventProc.md
@@ -46,7 +46,7 @@ Variant
 
 To handle event notifications, create a class module that implements the  **IVisEventProc** interface and then create an instance of this class to pass as an argument to the **AddAdvise** method of the **EventList** collection. Use the **AddAdvise** method to create **Event** objects that send the notifications.
 
-The  _nEventCode_ parameter identifes the specific event or events that occurred. The _EventCode_ argument of the **AddAdvise** method is passed to **VisEventProc** as _nEventCode_. Within your procedure, you can use any branching technique you want to determine which event occurred and handle it. The example that accompanies this topic uses a  **Select Case** decision structure.
+The  _nEventCode_ parameter identifies the specific event or events that occurred. The _EventCode_ argument of the **AddAdvise** method is passed to **VisEventProc** as _nEventCode_. Within your procedure, you can use any branching technique you want to determine which event occurred and handle it. The example that accompanies this topic uses a  **Select Case** decision structure.
 
 Unlike the  **Index** property of the **EventList** collection, _nEventID_ does not change as **Event** objects are added or deleted from the collection.
 

--- a/api/Visio.InvisibleApp.KeyDown.md
+++ b/api/Visio.InvisibleApp.KeyDown.md
@@ -52,7 +52,7 @@ If you set  _CancelDefault_ to **True** , Visio does not process the message rec
 Unlike some other Visio events,  **KeyDown** does not have the prefix "Query," but it is still a query event. That is, you can cancel processing the message sent by **KeyDown** , either by setting _CancelDefault_ to **True** , or, if you are using the **VisEventProc** method to handle the event, by returning **True**. For more information, see the topics for the **VisEventProc** method and for any of the query events (for example, the **QueryCancelSuspend** event) in this Automation Reference.
 
 > [!NOTE] 
-> Pressing an accelererator key combination, for example, CTRL + C, does not fire the  **KeyDown** event.
+> Pressing an accelerator key combination, for example, CTRL + C, does not fire the  **KeyDown** event.
 
 If you are using VBA, the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.InvisibleApp.KeyPress.md
+++ b/api/Visio.InvisibleApp.KeyPress.md
@@ -39,7 +39,7 @@ If you set  _CancelDefault_ to **True** , Visio does not process the message rec
 Unlike some other Visio events,  **KeyPress** does not have the prefix "Query," but it is still a query event. That is, you can cancel processing the message sent by **KeyPress** , either by setting _CancelDefault_ to **True** , or, if you are using the **VisEventProc** method to handle the event, by returning **True**. For more information, see the topics for the **VisEventProc** method and for any of the query events (for example, the **QueryCancelSuspend** event) in this Automation Reference.
 
 
- **Note**  Pressing an accelererator key combination, for example, CTRL + C, does not fire the  **KeyPress** event.
+ **Note**  Pressing an accelerator key combination, for example, CTRL + C, does not fire the  **KeyPress** event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.InvisibleApp.QueryCancelUngroup.md
+++ b/api/Visio.InvisibleApp.QueryCancelUngroup.md
@@ -42,7 +42,7 @@ A Microsoft Visio instance fires  **QueryCancelUngroup** after the user has dire
     
 
 
-While a Visio instance is firing a query or cancel event, it respondsto inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
+While a Visio instance is firing a query or cancel event, it responds to inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.InvisibleApp.UnregisterRibbonX.md
+++ b/api/Visio.InvisibleApp.UnregisterRibbonX.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # InvisibleApp.UnregisterRibbonX Method (Visio)
 
-Unregisters a previouly registered  **IRibbonExtensiblity** interface that a Microsoft Visio add-in implements.
+Unregisters a previously registered  **IRibbonExtensibility** interface that a Microsoft Visio add-in implements.
 
 
 ## Syntax

--- a/api/Visio.MarkupOverlaysVisible.md
+++ b/api/Visio.MarkupOverlaysVisible.md
@@ -33,11 +33,11 @@ A markup overlay is a layer that shows all the shapes, ink shapes, and comments 
 
 ## Example
 
-The following code shows how to turn off visiblity of markup overlays in Visio Viewer.
+The following code shows how to turn off visibility of markup overlays in Visio Viewer.
 
 
 ```vb
-vsoViewer.MarkupOverlaysVisble = False
+vsoViewer.MarkupOverlaysVisible = False
 ```
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Visio.Master.Document.md
+++ b/api/Visio.Master.Document.md
@@ -77,7 +77,7 @@ Public Sub Document_Example()
  'Get the Document object associated with various other objects.'Get the Document object associated with the Window object. 
  Set vsoTempDocument = vsoWindow.Document 
  
- 'Get the Title property of the Document object'to verify that this is the same document we added earlier. 
+ 'Get the Title property of the Document object to verify that this is the same document we added earlier. 
  Debug.Print vsoTempDocument.Title 
  
  'Get the Document object associated with the Page object. 

--- a/api/Visio.Master.QueryCancelUngroup.md
+++ b/api/Visio.Master.QueryCancelUngroup.md
@@ -45,7 +45,7 @@ A Microsoft Visio instance fires  **QueryCancelUngroup** after the user has dire
     
 
 
-While a Visio instance is firing a query or cancel event, it respondsto inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
+While a Visio instance is firing a query or cancel event, it responds to inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.Masters.Add.md
+++ b/api/Visio.Masters.Add.md
@@ -38,7 +38,7 @@ All properties of the new object are initialized to zero, so you need to set onl
 
 The following macro shows how to add  **Master** objects to the **Masters** collection and **Page** objects to the **Pages** collection. It also shows how to add documents, layers, styles, events, and add-ons to their corresponding collections.
 
-Before running this macro, replace  _Myfile.vsd_ with a valid .vsd file and references to _path_ \ _filename_ and _filename_ with a valid path and/or file name to an execuatable add-on (EXE) in your Visio project. The add-on should take no arguments.
+Before running this macro, replace  _Myfile.vsd_ with a valid .vsd file and references to _path_ \ _filename_ and _filename_ with a valid path and/or file name to an executable add-on (EXE) in your Visio project. The add-on should take no arguments.
 
 
 

--- a/api/Visio.Masters.GetNames.md
+++ b/api/Visio.Masters.GetNames.md
@@ -30,7 +30,7 @@ Returns the names of all items in a collection.
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _localeSpecificNameArray()_|Required| **STring**|Out parameter. An array that receives names of members of the indicated object.|
+| _localeSpecificNameArray()_|Required| **String**|Out parameter. An array that receives names of members of the indicated object.|
 
 ## Return value
 

--- a/api/Visio.Masters.QueryCancelUngroup.md
+++ b/api/Visio.Masters.QueryCancelUngroup.md
@@ -45,7 +45,7 @@ A Microsoft Visio instance fires  **QueryCancelUngroup** after the user has dire
     
 
 
-While a Visio instance is firing a query or cancel event, it respondsto inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
+While a Visio instance is firing a query or cancel event, it responds to inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.MenuItem.IsHierarchical.md
+++ b/api/Visio.MenuItem.IsHierarchical.md
@@ -64,7 +64,7 @@ Public Sub IsHierarchical_Example()
  Dim intCounterOuter As Integer 
  Dim intCounterInner As Integer 
  
- 'Get the UIOject object for the copy of the built-in menus. 
+ 'Get the UI Object object for the copy of the built-in menus. 
  Set vsoUIObject = Visio.Application.BuiltInMenus 
  
  'Set vsoMenuSet to the drawing menu set. 

--- a/api/Visio.Page.Document.md
+++ b/api/Visio.Page.Document.md
@@ -85,7 +85,7 @@ Public Sub Document_Example()
     'Get the Document object associated with various other objects.'Get the Document object associated with the Window object. 
     Set vsoTempDocument = vsoWindow.Document  
  
-    'Get the Title property of the Document object'to verify that this is the same document we added earlier.  
+    'Get the Title property of the Document object to verify that this is the same document we added earlier.  
     Debug.Print vsoTempDocument.Title  
  
     'Get the Document object associated with the Page object. 

--- a/api/Visio.Page.DropLinked.md
+++ b/api/Visio.Page.DropLinked.md
@@ -74,7 +74,7 @@ Public Sub DropLinked_Example()
     Dim dblY As Double  
     Dim lngDataRowID As Long 
     Dim vsoDataRecordset As Visio.DataRecordset 
-    Dim intRecordesetCount As Integer 
+    Dim intRecordsetCount As Integer 
  
     intRecordsetCount = Visio.ActiveDocument.DataRecordsets.Count 
     Set vsoDataRecordset = Visio.ActiveDocument.DataRecordsets(intRecordsetCount) 

--- a/api/Visio.Page.DropManyLinkedU.md
+++ b/api/Visio.Page.DropManyLinkedU.md
@@ -51,7 +51,7 @@ When you want to create shapes already linked to data on a drawing page that eit
 
 For the ObjectsToInstance() parameter, pass an array of objects to instance into shapes linked to data. While these objects are typically Visio objects such as  **Master** , **Shape** , or **Selection** objects, they can be any OLE objects that provide an **IDataObject** interface.
 
-For the XYs() parameter, pass an array of type  **Double**. Each consecutive pair of array-index-position values should correspond to the _x-_ and _y-_ page coordinates where you want the instance of the object in the corresponding positon in the ObjectsToInstance() array to be positioned. For example, if you want the instance of the object in the first array index position in ObjectsToInstance() to be positioned at page coordinate (2,4), place the value _2_ in the first array index position in XYs(), and place the value _4_ in the second array index positon in that array, and so on for the rest of the objects and coordinates.
+For the XYs() parameter, pass an array of type  **Double**. Each consecutive pair of array-index-position values should correspond to the _x-_ and _y-_ page coordinates where you want the instance of the object in the corresponding position in the ObjectsToInstance() array to be positioned. For example, if you want the instance of the object in the first array index position in ObjectsToInstance() to be positioned at page coordinate (2,4), place the value _2_ in the first array index position in XYs(), and place the value _4_ in the second array index position in that array, and so on for the rest of the objects and coordinates.
 
 When an object you pass in the ObjectsToInstance() array is a shape, the center of the shape's width-height box is positioned at the coordinates you specify in XYs().
 
@@ -84,7 +84,7 @@ Sub DropManyLinkedU_Example()
     Dim alngDataRowIDs(0 To 2) As Long 
     Dim alngShapeIDs() As Long 
     Dim vsoDataRecordset As Visio.DataRecordset 
-    Dim intRecordesetCount As Integer 
+    Dim intRecordsetCount As Integer 
     Dim lngReturned As Long 
     Dim intCounter As Integer 
      

--- a/api/Visio.Page.QueryCancelUngroup.md
+++ b/api/Visio.Page.QueryCancelUngroup.md
@@ -45,7 +45,7 @@ A Microsoft Visio instance fires  **QueryCancelUngroup** after the user has dire
     
 
 
-While a Visio instance is firing a query or cancel event, it respondsto inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
+While a Visio instance is firing a query or cancel event, it responds to inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.Pages.Add.md
+++ b/api/Visio.Pages.Add.md
@@ -38,7 +38,7 @@ All properties of the new object are initialized to zero, so you need to set onl
 
 The following macro shows how to add  **Master** objects to the **Masters** collection and **Page** objects to the **Pages** collection. It also shows how to add documents, layers, styles, events, and add-ons to their corresponding collections.
 
-Before running this macro, replace  _Myfile.vsd_ with a valid .vsd file and references to _path_ \ _filename_ and _filename_ with a valid path and/or file name to an execuatable add-on (EXE) in your Visio project. The add-on should take no arguments.
+Before running this macro, replace  _Myfile.vsd_ with a valid .vsd file and references to _path_ \ _filename_ and _filename_ with a valid path and/or file name to an executable add-on (EXE) in your Visio project. The add-on should take no arguments.
 
 
 

--- a/api/Visio.Pages.QueryCancelUngroup.md
+++ b/api/Visio.Pages.QueryCancelUngroup.md
@@ -45,7 +45,7 @@ A Microsoft Visio instance fires  **QueryCancelUngroup** after the user has dire
     
 
 
-While a Visio instance is firing a query or cancel event, it respondsto inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
+While a Visio instance is firing a query or cancel event, it responds to inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.PriFormat.md
+++ b/api/Visio.PriFormat.md
@@ -39,7 +39,7 @@ Possible values for the  **PriFormat** property are as follows:
     
 - SVG (Scalable Vector Graphics)
     
-- JPG (JPEG File Interchage Format)
+- JPG (JPEG File Interchange Format)
     
 - GIF (Graphics Interchange Format)
     

--- a/api/Visio.RelatedShapePairEvent.FromShapeID.md
+++ b/api/Visio.RelatedShapePairEvent.FromShapeID.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # RelatedShapePairEvent.FromShapeID Property (Visio)
 
-Returrns the identifier of the first (container or callout) shape in the related shape pair. Read-only.
+Returns the identifier of the first (container or callout) shape in the related shape pair. Read-only.
 
 
 ## Syntax

--- a/api/Visio.RelatedShapePairEvent.ToShapeID.md
+++ b/api/Visio.RelatedShapePairEvent.ToShapeID.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # RelatedShapePairEvent.ToShapeID Property (Visio)
 
-Returrns the identifier of the second (member) shape in the related shape pair. Read-only.
+Returns the identifier of the second (member) shape in the related shape pair. Read-only.
 
 
 ## Syntax

--- a/api/Visio.ReviewerColor.md
+++ b/api/Visio.ReviewerColor.md
@@ -27,7 +27,7 @@ Gets the color of the markup overlay associated with the specified reviewer in t
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-|ReviewerIndex|Required| **Long**|The index of the reviewer in the collection of reveiwers.|
+|ReviewerIndex|Required| **Long**|The index of the reviewer in the collection of reviewers.|
 
 ## Return value
 

--- a/api/Visio.SecFormat.md
+++ b/api/Visio.SecFormat.md
@@ -37,7 +37,7 @@ Possible values for the  **SecFormat** property are as follows:
 
 - PNG (Portable Network Graphics), the default
     
-- JPG (JPEG File Interchage Format)
+- JPG (JPEG File Interchange Format)
     
 - GIF (Graphics Interchange Format)
     

--- a/api/Visio.Selection.Flip.md
+++ b/api/Visio.Selection.Flip.md
@@ -31,7 +31,7 @@ Flips selected shapes either as a group or individually about their pins. Return
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
 | _FlipDirection_|Required| **VisFlipDirection**|Specifies the direction in which to flip the selection. See Remarks for possible values.|
-| _FlipType_|Optional| **VisFlipTypes**|Specifes how selection is to be flipped. See Remarks for possible values.|
+| _FlipType_|Optional| **VisFlipTypes**|Specifies how selection is to be flipped. See Remarks for possible values.|
 | _BlastGuards_|Optional| **Boolean**| **True** to override formulas in the ShapeSheet of any of the selected shapes to which the GUARD function has been applied; **False** to leave guarded formulas unchanged. The default is **False**.|
 | _PinX_|Optional| **Double**|When  _FlipType_ is **visFlipSelectionWithPin** , specifies the X-position of the pin about which the selection is to be flipped.|
 | _PinY_|Optional| **Double**|When  _FlipType_ is **visFlipSelectionWithPin** , specifies the Y-position of the pin about which the selection is to be flipped.|

--- a/api/Visio.Selection.Rotate.md
+++ b/api/Visio.Selection.Rotate.md
@@ -33,7 +33,7 @@ Rotates selected shapes either as a group or individually about their pins.
 | _Angle_|Required| **Double**|Specifies the angle to rotate the selection. See Remarks for possible values.|
 | _AngleUnitsNameOrCode_|Optional| **Variant**|Specifies the units to use for  _Angle_. See Remarks for possible values. The default is degrees.|
 | _BlastGuards_|Optional| **Boolean**| **True** to override formulas in the ShapeSheet of any of the selected shapes to which the GUARD function has been applied; **False** to leave guarded formulas unchanged. The default is **False**.|
-| _RotationType_|Optional| **VisRotationTypes**|Specifes how the selection is to be rotated. See Remarks for possible values.|
+| _RotationType_|Optional| **VisRotationTypes**|Specifies how the selection is to be rotated. See Remarks for possible values.|
 | _PinX_|Optional| **Double**|When  _RotationType_ is **visRotateSelectionWithPin** , specifies the X-position of the pin about which the selection is to be rotated.|
 | _PinY_|Optional| **Double**| When _RotationType_ is **visRotateSelectionWithPin** , specifies the Y-position of the pin about which the selection is to be rotated.|
 | _PinUnitsNameOrCode_|Optional| **Variant**|Specifies the units to use for  _PinX_ and _PinY_. See Remarks for possible values. The default is inches.|

--- a/api/Visio.Shape.IsDataGraphicCallout.md
+++ b/api/Visio.Shape.IsDataGraphicCallout.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 
 # Shape.IsDataGraphicCallout Property (Visio)
 
-Specifes whether a shape is a data graphic callout. Read-only.
+Specifies whether a shape is a data graphic callout. Read-only.
 
 
  **Note**  This Visio object or member is available only to licensed users of Visio Professional 2013.

--- a/api/Visio.Shape.QueryCancelUngroup.md
+++ b/api/Visio.Shape.QueryCancelUngroup.md
@@ -45,7 +45,7 @@ A Microsoft Visio instance fires  **QueryCancelUngroup** after the user has dire
     
 
 
-While a Visio instance is firing a query or cancel event, it respondsto inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
+While a Visio instance is firing a query or cancel event, it responds to inquiries from client code but refuses to perform operations. Client code can show forms or message boxes while responding to a query or cancel event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.Toolbar.Enabled.md
+++ b/api/Visio.Toolbar.Enabled.md
@@ -105,7 +105,7 @@ Sub Enabled_Example()
  
  End With 
  
- 'Tell Visio to use the new UIOjbect object while 
+ 'Tell Visio to use the new UIObject object while 
  'this document is active. 
  ThisDocument.SetCustomToolbars vsoUIObject 
  

--- a/api/Visio.ToolbarItem.Enabled.md
+++ b/api/Visio.ToolbarItem.Enabled.md
@@ -113,7 +113,7 @@ Sub Enabled_Example()
  
  End With 
  
- 'Tell Visio to use the new UIOjbect object while 
+ 'Tell Visio to use the new UIObject object while 
  'this document is active. 
  ThisDocument.SetCustomToolbars vsoUIObject 
  

--- a/api/Visio.ToolbarItem.Style.md
+++ b/api/Visio.ToolbarItem.Style.md
@@ -49,7 +49,7 @@ Possible values for the  **Style** property are listed in the following table. T
 
 This example shows how to use the  **Style** property to set the style of a toolbar button. The example adds a custom toolbar button and sets it to display both an icon and a caption. This button appears in the Visio user interface and is available while the document is active.
 
-Before running this code, replace  _path\filename_ with the full path to and name of a valid icone (.ico) file on your computer.
+Before running this code, replace  _path\filename_ with the full path to and name of a valid icon (.ico) file on your computer.
 
 To restore the built-in toolbars in Microsoft Visio after you run this macro, call the  **ThisDocument.ClearCustomToolbars** method.
 

--- a/api/Visio.Validation.Validate.md
+++ b/api/Visio.Validation.Validate.md
@@ -53,7 +53,7 @@ To validate all rule sets active in the document, pass  **Nothing** for _RuleSet
 
 If you do not set the optional  _Flags_ parameter, Microsoft Visio applies the default behavior (**visValidationDefault**).
 
-When you call the  **Validate** method, Microsoft Visio checks whether the rule set is active before evaluating it. Visio does not display message boxes during the evalution, except to notify you if, when _Flags_ is set to **visValidationDefault** , it finds no errors; and it displays the progress bar only if **Application.ShowProgressBars** is **True**.
+When you call the  **Validate** method, Microsoft Visio checks whether the rule set is active before evaluating it. Visio does not display message boxes during the evaluation, except to notify you if, when _Flags_ is set to **visValidationDefault** , it finds no errors; and it displays the progress bar only if **Application.ShowProgressBars** is **True**.
 
 
 ## Example

--- a/api/Visio.Window.Document.md
+++ b/api/Visio.Window.Document.md
@@ -84,7 +84,7 @@ Public Sub Document_Example()
  'Get the Document object associated with various other objects.'Get the Document object associated with the Window object. 
  Set vsoTempDocument = vsoWindow.Document 
  
- 'Get the Title property of the Document object'to verify that this is the same document we added earlier. 
+ 'Get the Title property of the Document object to verify that this is the same document we added earlier. 
  Debug.Print vsoTempDocument.Title 
  
  'Get the Document object associated with the Page object. 

--- a/api/Visio.Window.KeyDown.md
+++ b/api/Visio.Window.KeyDown.md
@@ -55,7 +55,7 @@ If you set  _CancelDefault_ to **True** , Visio does not process the message rec
 Unlike some other Visio events,  **KeyDown** does not have the prefix "Query," but it is still a query event. That is, you can cancel processing the message sent by **KeyDown** , either by setting _CancelDefault_ to **True** , or, if you are using the **VisEventProc** method to handle the event, by returning **True**. For more information, see the topics for the **VisEventProc** method and for any of the query events (for example, the **QueryCancelSuspend** event) in this Automation Reference.
 
 > [!NOTE] 
-> Pressing an accelererator key combination, for example, CTRL + C, does not fire the  **KeyDown** event.
+> Pressing an accelerator key combination, for example, CTRL + C, does not fire the  **KeyDown** event.
 
 If you are using VBA, the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.Window.KeyPress.md
+++ b/api/Visio.Window.KeyPress.md
@@ -42,7 +42,7 @@ If you set  _CancelDefault_ to **True** , Visio does not process the message rec
 Unlike some other Visio events,  **KeyPress** does not have the prefix "Query," but it is still a query event. That is, you can cancel processing the message sent by **KeyPress** , either by setting _CancelDefault_ to **True** , or, if you are using the **VisEventProc** method to handle the event, by returning **True**. For more information, see the topics for the **VisEventProc** method and for any of the query events (for example, the **QueryCancelSuspend** event) in this Automation Reference.
 
 
- **Note**  Pressing an accelererator key combination, for example, CTRL + C, does not fire the  **KeyPress** event.
+ **Note**  Pressing an accelerator key combination, for example, CTRL + C, does not fire the  **KeyPress** event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.Windows.KeyDown.md
+++ b/api/Visio.Windows.KeyDown.md
@@ -56,7 +56,7 @@ Unlike some other Visio events,  **KeyDown** does not have the prefix "Query," b
 
 
  > [!NOTE] 
- > Pressing an accelererator key combination, for example, CTRL + C, does not fire the  **KeyDown** event.
+ > Pressing an accelerator key combination, for example, CTRL + C, does not fire the  **KeyDown** event.
 
 If you are using VBA, the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.Windows.KeyPress.md
+++ b/api/Visio.Windows.KeyPress.md
@@ -42,7 +42,7 @@ If you set  _CancelDefault_ to **True** , Visio does not process the message rec
 Unlike some other Visio events,  **KeyPress** does not have the prefix "Query," but it is still a query event. That is, you can cancel processing the message sent by **KeyPress** , either by setting _CancelDefault_ to **True** , or, if you are using the **VisEventProc** method to handle the event, by returning **True**. For more information, see the topics for the **VisEventProc** method and for any of the query events (for example, the **QueryCancelSuspend** event) in this Automation Reference.
 
 
- **Note**  Pressing an accelererator key combination, for example, CTRL + C, does not fire the  **KeyPress** event.
+ **Note**  Pressing an accelerator key combination, for example, CTRL + C, does not fire the  **KeyPress** event.
 
 If you are using Microsoft Visual Basic or Visual Basic for Applications (VBA), the syntax in this topic describes a common, efficient way to handle events.
 

--- a/api/Visio.ZoomToRect.md
+++ b/api/Visio.ZoomToRect.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 
 # Viewer.ZoomToRect Method (Visio Viewer)
 
-Zooms to display a rectanglular section, specified by the parameters, of the drawing that is open in Microsoft Visio Viewer.
+Zooms to display a rectangular section, specified by the parameters, of the drawing that is open in Microsoft Visio Viewer.
 
 
 ## Syntax

--- a/api/Word.CanvasShapes.AddCurve.md
+++ b/api/Word.CanvasShapes.AddCurve.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # CanvasShapes.AddCurve method (Word)
 
-Returns a  **[Shape](Word.Shape.md)** object that represents a B?zier curve in a drawing canvas.
+Returns a  **[Shape](Word.Shape.md)** object that represents a Bézier curve in a drawing canvas.
 
 
 ## Syntax
@@ -30,11 +30,11 @@ Returns a  **[Shape](Word.Shape.md)** object that represents a B?zier curve in a
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _SafeArrayOfPoints_|Required| **Variant**|An array of coordinate pairs that specifies the vertices and control points of the curve. The first point you specify is the starting vertex, and the next two points are control points for the first B?zier segment. Then, for each additional segment of the curve, you specify a vertex and two control points. The last point you specify is the ending vertex for the curve. Note that you must always specify 3n + 1 points, where n is the number of segments in the curve.|
+| _SafeArrayOfPoints_|Required| **Variant**|An array of coordinate pairs that specifies the vertices and control points of the curve. The first point you specify is the starting vertex, and the next two points are control points for the first Bézier segment. Then, for each additional segment of the curve, you specify a vertex and two control points. The last point you specify is the ending vertex for the curve. Note that you must always specify 3n + 1 points, where n is the number of segments in the curve.|
 
 ## Example
 
-This example adds a B?zier curve to a new drawing canvas.
+This example adds a Bézier curve to a new drawing canvas.
 
 
 ```vb

--- a/api/Word.Categories.md
+++ b/api/Word.Categories.md
@@ -16,7 +16,7 @@ Represents a collection of building block categories.
 
 ## Remarks
 
-Use the  **Item** method to access an exising category. You can then use the **[BuildingBlocks](Word.Category.BuildingBlocks.md)** property to access a collection of **[BuildingBlock](Word.BuildingBlock.md)** objects for the category. The following example prints the type and category names of all the building blocks in the first template to the **Immediate Window**. (This example assumes that the **Immediate Window** is visible.)
+Use the  **Item** method to access an existing category. You can then use the **[BuildingBlocks](Word.Category.BuildingBlocks.md)** property to access a collection of **[BuildingBlock](Word.BuildingBlock.md)** objects for the category. The following example prints the type and category names of all the building blocks in the first template to the **Immediate Window**. (This example assumes that the **Immediate Window** is visible.)
 
 
 ```vb
@@ -40,7 +40,7 @@ For intCount = 1 To objTemplate.BuildingBlockTypes.Count
 Next
 ```
 
-Use the  **Item** method to access an exising category; to create a new category, use the **Add** method of the **BuildingBlockEntries** collection. Set the value of the Category parameter.
+Use the  **Item** method to access an existing category; to create a new category, use the **Add** method of the **BuildingBlockEntries** collection. Set the value of the Category parameter.
 
 For more information about building blocks, see [Working with Building Blocks](../word/Concepts/Working-with-Word/working-with-building-blocks.md).
 

--- a/api/Word.Category.md
+++ b/api/Word.Category.md
@@ -47,7 +47,7 @@ For intCount = 1 To objTemplate.BuildingBlockTypes.Count
 Next
 ```
 
-Use the  **Item** method of the **Categories** collection to access an exising category; to create a new category, use the **Add** method of the **BuildingBlockEntries** collection. Set the value of the Category parameter.
+Use the  **Item** method of the **Categories** collection to access an existing category; to create a new category, use the **Add** method of the **BuildingBlockEntries** collection. Set the value of the Category parameter.
 
 For more information about building blocks, see [Working with Building Blocks](../word/Concepts/Working-with-Word/working-with-building-blocks.md).
 

--- a/api/Word.Chart.ShowAxisFieldButtons.md
+++ b/api/Word.Chart.ShowAxisFieldButtons.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Chart.ShowAxisFieldButtons property (Word)
 
-Returns or sets whether to display axis field buttons on a PivotChart. Read/write. Depcrecated.
+Returns or sets whether to display axis field buttons on a PivotChart. Read/write. Deprecated.
 
 
 ## Syntax

--- a/api/Word.ContentControl.ParentContentControl.md
+++ b/api/Word.ContentControl.ParentContentControl.md
@@ -26,7 +26,7 @@ Returns a  **ContentControl** that represents the parent content control for a c
 
 ## Remarks
 
-If a content control is not nested, this proprerty returns an error.
+If a content control is not nested, this property returns an error.
 
 
 ## See also

--- a/api/Word.DefaultWebOptions.FolderSuffix.md
+++ b/api/Word.DefaultWebOptions.FolderSuffix.md
@@ -75,7 +75,7 @@ The following table lists each language version of Office and gives its correspo
 |Swedish|1053|-filer|
 |Thai|1054|.files|
 |Turkish|1055|_dosyalar|
-|Ukranian|1058|.files|
+|Ukrainian|1058|.files|
 |Vietnamese|1066|.files|
 
 

--- a/api/Word.Document.DetectLanguage.md
+++ b/api/Word.Document.DetectLanguage.md
@@ -28,7 +28,7 @@ Analyzes the specified text to determine the language that it is written in.
 
 When applied to a  **Document** object, the **DetectLanguage** method checks all available text in the document (headers, footers, text boxes, and so forth). If the specified text contains a partial sentence, the selection or range is extended to the end of the sentence.
 
-If the  **DetectLanguage** method has already been applied to the specified text, the **[LanguageDetected](Word.Document.LanguageDetected.md)** property is set to **True**. To re-evaulate the language of the specified text, you must first set the **LanguageDetected** property to **False**.
+If the  **DetectLanguage** method has already been applied to the specified text, the **[LanguageDetected](Word.Document.LanguageDetected.md)** property is set to **True**. To re-evaluate the language of the specified text, you must first set the **LanguageDetected** property to **False**.
 
 
 ## Example

--- a/api/Word.Document.HasVBProject.md
+++ b/api/Word.Document.HasVBProject.md
@@ -26,7 +26,7 @@ Returns a  **Boolean** that represents whether a document has an attached Micros
 
 ## Remarks
 
-This property is most useful in programatically determining whether a document needs to be saved into a macro-enabled file format. If saved in another format, macros and code projects contained within the document may be lost.
+This property is most useful in programmatically determining whether a document needs to be saved into a macro-enabled file format. If saved in another format, macros and code projects contained within the document may be lost.
 
 
 ## See also

--- a/api/Word.Document.XMLBeforeDelete.md
+++ b/api/Word.Document.XMLBeforeDelete.md
@@ -61,7 +61,7 @@ End Sub
 
 ## Example
 
-The following example runs when an XML element is deleted. If the element contains text, a message is displayed asking whether the user wants to delete the text the element contains. If the user reponds by clicking No, the contents of the element are copied to the Clipboard.
+The following example runs when an XML element is deleted. If the element contains text, a message is displayed asking whether the user wants to delete the text the element contains. If the user responds by clicking No, the contents of the element are copied to the Clipboard.
 
 
 ```vb

--- a/api/Word.EmailOptions.AutoFormatAsYouTypeAutoLetterWizard.md
+++ b/api/Word.EmailOptions.AutoFormatAsYouTypeAutoLetterWizard.md
@@ -30,7 +30,7 @@ This example sets Microsoft Word to automatically start the Letter Wizard when t
 
 
 ```vb
-Sub AutoLeterWizard() 
+Sub AutoLetterWizard() 
  Options.AutoFormatAsYouTypeAutoLetterWizard = True 
 End Sub
 ```

--- a/api/Word.FileConverter.OpenFormat.md
+++ b/api/Word.FileConverter.OpenFormat.md
@@ -26,7 +26,7 @@ Returns the file format of the specified file converter. Read-only  **Long**.
 
 ## Remarks
 
-This property can be any vailid  **WdOpenFormat** constant, or it can be a unique number that represents an external file converter.
+This property can be any valid  **WdOpenFormat** constant, or it can be a unique number that represents an external file converter.
 
 
 ## Example

--- a/api/Word.Frameset.md
+++ b/api/Word.Frameset.md
@@ -19,7 +19,7 @@ Represents an entire frames page or a single frame on a frames page.
 
 ## Remarks
 
-Use the  **Frameset** propertyof a **Document** or **Pane** object to return a **Frameset** object.
+Use the  **Frameset** property of a **Document** or **Pane** object to return a **Frameset** object.
 
 
 -  For properties or methods that affect all frames on a frames page, use the **Frameset** object from the **Document** object ( `ActiveWindow.Document.Frameset`).

--- a/api/Word.OMathFunctions.Add.md
+++ b/api/Word.OMathFunctions.Add.md
@@ -30,7 +30,7 @@ Inserts a new structure, such as a fraction, into an equation at the specified p
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _Range_|Required| **Range**| The place at which to insrt an equation.|
+| _Range_|Required| **Range**| The place at which to insert an equation.|
 | _Type_|Required| **WdOMathFunctionType**|The type of equation to insert.|
 | _NumArgs_|Optional| **Variant**| The number of arguments in the equation.|
 | _NumCols_|Optional| **Variant**|The number of columns in the equation.|

--- a/api/Word.OMathMatRows.md
+++ b/api/Word.OMathMatRows.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # OMathMatRows object (Word)
 
-Represents a collection of matrix rows. Use the  **OMathMatRow** object to access individual membes of the collection.
+Represents a collection of matrix rows. Use the  **OMathMatRow** object to access individual members of the collection.
 
 
 ## See also

--- a/api/Word.Options.AutoFormatAsYouTypeAutoLetterWizard.md
+++ b/api/Word.Options.AutoFormatAsYouTypeAutoLetterWizard.md
@@ -30,7 +30,7 @@ This example sets Microsoft Word to automatically start the Letter Wizard when t
 
 
 ```vb
-Sub AutoLeterWizard() 
+Sub AutoLetterWizard() 
  Options.AutoFormatAsYouTypeAutoLetterWizard = True 
 End Sub
 ```

--- a/api/Word.Options.ContextualSpeller.md
+++ b/api/Word.Options.ContextualSpeller.md
@@ -26,7 +26,7 @@ Returns or sets a  **Boolean** that represents whether to use the contextual spe
 
 ## Remarks
 
-The contextual speller indentifies the structure of words and their location within a sentence to determine if spelling is correct. It can find errors that the standard spelling checker cannot find. For example, a user might type "superb owl" instead of "super bowl". Because both "superb" and "owl" are correctly spelled words, the standard spelling checker would not find an error. Based on the words in context of the sentence and the words around them, the contextual speller determines that the correct words are "super" and "bowl" and makes the change automatically.
+The contextual speller identifies the structure of words and their location within a sentence to determine if spelling is correct. It can find errors that the standard spelling checker cannot find. For example, a user might type "superb owl" instead of "super bowl". Because both "superb" and "owl" are correctly spelled words, the standard spelling checker would not find an error. Based on the words in context of the sentence and the words around them, the contextual speller determines that the correct words are "super" and "bowl" and makes the change automatically.
 
 This property corresponds to the  **Use contextual spelling** check box in the **Proofing** tab of the **Word Options** dialog box.
 

--- a/api/Word.ProtectedViewWindow.Width.md
+++ b/api/Word.ProtectedViewWindow.Width.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # ProtectedViewWindow.Width property (Word)
 
-Returns or sets the width, in points, of the specified protectd view window. Read/write  **Long**.
+Returns or sets the width, in points, of the specified protected view window. Read/write  **Long**.
 
 
 ## Syntax

--- a/api/Word.Range.DetectLanguage.md
+++ b/api/Word.Range.DetectLanguage.md
@@ -34,7 +34,7 @@ When applied to a  **Document** object, the **DetectLanguage** method checks all
 
 
 
-If the  **DetectLanguage** method has already been applied to the specified text, the **LanguageDetected** property is set to **True**. To reevaulate the language of the specified text, you must first set the **[LanguageDetected](Word.Document.LanguageDetected.md)** property to **False**.
+If the  **DetectLanguage** method has already been applied to the specified text, the **LanguageDetected** property is set to **True**. To reevaluate the language of the specified text, you must first set the **[LanguageDetected](Word.Document.LanguageDetected.md)** property to **False**.
 
 
 

--- a/api/Word.Selection.DetectLanguage.md
+++ b/api/Word.Selection.DetectLanguage.md
@@ -30,7 +30,7 @@ The results of the  **DetectLanguage** method are stored in the **LanguageID** p
 
 If a selection contains a partial sentence, the selection is extended to the end of the sentence.
 
-If the  **DetectLanguage** method has already been applied to the specified text, the **LanguageDetected** property is set to **True**. To reevaulate the language of the specified text, you must first set the **[LanguageDetected](Word.Document.LanguageDetected.md)** property to **False**.
+If the  **DetectLanguage** method has already been applied to the specified text, the **LanguageDetected** property is set to **True**. To reevaluate the language of the specified text, you must first set the **[LanguageDetected](Word.Document.LanguageDetected.md)** property to **False**.
 
 
 ## See also

--- a/api/Word.Selection.Endnotes.md
+++ b/api/Word.Selection.Endnotes.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Selection.Endnotes property (Word)
 
-Returns an  **[Endnotes](Word.endnotes.md)** collection that represents all the endnotes conatined within a selection. Read-only.
+Returns an  **[Endnotes](Word.endnotes.md)** collection that represents all the endnotes contained within a selection. Read-only.
 
 
 ## Syntax

--- a/api/Word.Selection.InsertCells.md
+++ b/api/Word.Selection.InsertCells.md
@@ -30,7 +30,7 @@ Adds cells to an existing table.
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _ShiftCells_|Optional| **WdInsertCells**|Specifies how to insert the cells into the existing columns and rows of the tabel.|
+| _ShiftCells_|Optional| **WdInsertCells**|Specifies how to insert the cells into the existing columns and rows of the table.|
 
 ## Remarks
 

--- a/api/Word.Shape.Vertices.md
+++ b/api/Word.Shape.Vertices.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Shape.Vertices property (Word)
 
-Returns the coordinates of the specified freeform drawing's vertices (and control points for B?zier curves) as a series of coordinate pairs. Read-only  **Variant**.
+Returns the coordinates of the specified freeform drawing's vertices (and control points for Bézier curves) as a series of coordinate pairs. Read-only  **Variant**.
 
 
 ## Syntax
@@ -55,7 +55,7 @@ With ActiveDocument.Shapes(1)
 End With
 ```
 
-This example creates a curve that has the same geometric description as shape one in the active document. This example assumes that the first shape is a B?zier curve containing 3n+1 vertices, where n is the number of curve segments.
+This example creates a curve that has the same geometric description as shape one in the active document. This example assumes that the first shape is a Bézier curve containing 3n+1 vertices, where n is the number of curve segments.
 
 
 

--- a/api/Word.ShapeRange.Vertices.md
+++ b/api/Word.ShapeRange.Vertices.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # ShapeRange.Vertices property (Word)
 
-Returns the coordinates of the specified freeform drawing's vertices (and control points for B?zier curves) as a series of coordinate pairs. You can use the array returned by this property as an argument for the  **AddCurve** or **AddPolyLine** method. Read-only **Variant**.
+Returns the coordinates of the specified freeform drawing's vertices (and control points for Bézier curves) as a series of coordinate pairs. You can use the array returned by this property as an argument for the  **AddCurve** or **AddPolyLine** method. Read-only **Variant**.
 
 
 ## Syntax

--- a/api/Word.Shapes.AddCurve.md
+++ b/api/Word.Shapes.AddCurve.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Shapes.AddCurve method (Word)
 
-Returns a  **[Shape](Word.Shape.md)** object that represents a B?zier curve in a drawing canvas.
+Returns a  **[Shape](Word.Shape.md)** object that represents a Bézier curve in a drawing canvas.
 
 
 ## Syntax
@@ -30,7 +30,7 @@ Returns a  **[Shape](Word.Shape.md)** object that represents a B?zier curve in a
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _SafeArrayOfPoints_|Required| **Variant**|An array of coordinate pairs that specifies the vertices and control points of the curve. The first point you specify is the starting vertex, and the next two points are control points for the first B?zier segment. Then, for each additional segment of the curve, you specify a vertex and two control points. The last point you specify is the ending vertex for the curve. Note that you must always specify 3n + 1 points, where n is the number of segments in the curve.|
+| _SafeArrayOfPoints_|Required| **Variant**|An array of coordinate pairs that specifies the vertices and control points of the curve. The first point you specify is the starting vertex, and the next two points are control points for the first Bézier segment. Then, for each additional segment of the curve, you specify a vertex and two control points. The last point you specify is the ending vertex for the curve. Note that you must always specify 3n + 1 points, where n is the number of segments in the curve.|
 
 ## Return value
 
@@ -39,7 +39,7 @@ Returns a  **[Shape](Word.Shape.md)** object that represents a B?zier curve in a
 
 ## Example
 
-This example adds a B?zier curve to a new drawing canvas.
+This example adds a Bézier curve to a new drawing canvas.
 
 
 ```vb

--- a/api/Word.Style.Description.md
+++ b/api/Word.Style.Description.md
@@ -26,7 +26,7 @@ Returns the description of the specified style. Read-only  **String**.
 
 ## Remarks
 
-A typical example of a descirption for a style might be "Normal + Font: Arial, 12 pt, Bold, Italic, Space Before 12 pt After 3 pt, KeepWithNext, Level 2."
+A typical example of a description for a style might be "Normal + Font: Arial, 12 pt, Bold, Italic, Space Before 12 pt After 3 pt, KeepWithNext, Level 2."
 
 
 ## Example

--- a/api/Word.TableOfFigures.TabLeader.md
+++ b/api/Word.TableOfFigures.TabLeader.md
@@ -26,7 +26,7 @@ Returns or sets the character between entries and their page numbers in an table
 
 ## Example
 
-This example formats the tables of firgures in Sales.doc to use a dotted tab leader.
+This example formats the tables of figures in Sales.doc to use a dotted tab leader.
 
 
 ```vb

--- a/api/Word.Task.SendWindowMessage.md
+++ b/api/Word.Task.SendWindowMessage.md
@@ -30,12 +30,12 @@ Sends a Windows message and its associated parameters to the specified task.
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _Message_|Required| **Long**|A hexidecimal number that corresponds to the message you want to send. If you have the Microsoft Platform Software Development Kit, you can look up the name of the message in the header files (Winuser.h, for example) to find the associated hexadecimal number (precede the hexidecimal value with &h).|
+| _Message_|Required| **Long**|A hexadecimal number that corresponds to the message you want to send. If you have the Microsoft Platform Software Development Kit, you can look up the name of the message in the header files (Winuser.h, for example) to find the associated hexadecimal number (precede the hexadecimal value with &h).|
 | _wParam_|Required| **Long**|Parameters appropriate for the message you are sending. For information about what these values represent, see the reference topic for that message in the documentation included with the Microsoft Platform Software Development Kit, available on MSDN. To retrieve the appropriate values, you may need to use the Spy tool (which comes with the kit).|
 
 ## Example
 
-If Notepad is running, this example displays the  **About** dialog box (in Notepad) by sending a WM_COMMAND message to Notepad. The **SendWindowMessage** method is used to send the WM_COMMAND message (111 is the hexidecimal value for WM_COMMAND), with the parameters 11 and 0. The Spy tool was used to determine the **wParam** and **lParam** values.
+If Notepad is running, this example displays the  **About** dialog box (in Notepad) by sending a WM_COMMAND message to Notepad. The **SendWindowMessage** method is used to send the WM_COMMAND message (111 is the hexadecimal value for WM_COMMAND), with the parameters 11 and 0. The Spy tool was used to determine the **wParam** and **lParam** values.
 
 
 ```vb

--- a/api/Word.WdExportOptimizeFor.md
+++ b/api/Word.WdExportOptimizeFor.md
@@ -18,6 +18,6 @@ Specifies the resolution and quality of the exported document.
 |Name|Value|Description|
 |:-----|:-----|:-----|
 | **wdExportOptimizeForOnScreen**|1|Export for screen, which is a lower quality and results in a smaller file size.|
-| **wdExportOptimizeForPrint**|0|Export for print, which is higher quailty and results in a larger file size.|
+| **wdExportOptimizeForPrint**|0|Export for print, which is higher quality and results in a larger file size.|
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Word.WdWrapType.md
+++ b/api/Word.WdWrapType.md
@@ -19,7 +19,7 @@ Specifies how to wrap text around a shape.
 |:-----|:-----|:-----|
 | **wdWrapInline**|7|Places shapes in line with text.|
 | **wdWrapNone**|3|Places shape in front of text. See also  **wdWrapFront**.|
-| **wdWrapSquare**|0|Wraps text around the shape. Line continuation is on the oposite side of the shape.|
+| **wdWrapSquare**|0|Wraps text around the shape. Line continuation is on the opposite side of the shape.|
 | **wdWrapThrough**|2|Wraps text around the shape.|
 | **wdWrapTight**|1|Wraps text close to the shape.|
 | **wdWrapTopBottom**|4|Places text above and below the shape.|

--- a/api/Word.WebOptions.FolderSuffix.md
+++ b/api/Word.WebOptions.FolderSuffix.md
@@ -73,7 +73,7 @@ The following table lists each language version of Office and gives its correspo
 |Swedish|1053|-filer|
 |Thai|1054|.files|
 |Turkish|1055|_dosyalar|
-|Ukranian|1058|.files|
+|Ukrainian|1058|.files|
 |Vietnamese|1066|.files|
 
 ## Example

--- a/api/Word.Window.ToggleRibbon.md
+++ b/api/Word.Window.ToggleRibbon.md
@@ -26,7 +26,7 @@ Shows or hides the ribbon.
 
 ## Remarks
 
-If the ribbon is visible, the  **TobbleRibbon** method hides it; if the ribbon is hidden, the **ToggleRibbon** method shows it.
+If the ribbon is visible, the  **ToggleRibbon** method hides it; if the ribbon is hidden, the **ToggleRibbon** method shows it.
 
 
 ## See also

--- a/api/Word.fileconverters.md
+++ b/api/Word.fileconverters.md
@@ -27,7 +27,7 @@ Next conv
 
 The  **Add** method isn't available for the **FileConverters** collection. **[FileConverter](Word.FileConverter.md)** objects are added during installation of Microsoft Office or by installing supplemental converters.
 
-Use  **FileConverters** (Index), where Index is a class name or index number, to return a single **[FileConverter](Word.FileConverter.md)** object. The following example displays the extensions associated wtih the Microsoft Excel worksheet converter.
+Use  **FileConverters** (Index), where Index is a class name or index number, to return a single **[FileConverter](Word.FileConverter.md)** object. The following example displays the extensions associated with the Microsoft Excel worksheet converter.
 
 
 

--- a/api/Word.xlpattern.md
+++ b/api/Word.xlpattern.md
@@ -33,7 +33,7 @@ Specifies the interior pattern of a chart or interior object.
 | **xlPatternLinearGradient**|4000|A linear gradient.|
 | **xlPatternNone**|-4142|No pattern.|
 | **xlPatternRectangularGradient**|4001|A rectangular gradient.|
-| **xlPatternSemiGray75**|10|75% dark moir?.|
+| **xlPatternSemiGray75**|10|75% dark moiré.|
 | **xlPatternSolid**|1|A solid color.|
 | **xlPatternUp**|-4162|Dark diagonal lines running from the lower left to the upper right.|
 | **xlPatternVertical**|-4166|Dark vertical bars.|

--- a/api/Word.xltrendlinetype.md
+++ b/api/Word.xltrendlinetype.md
@@ -9,7 +9,7 @@ localization_priority: Normal
 
 # XlTrendlineType enumeration (Word)
 
-Specifies how the trendline that smoothes out fluctuations in the data is calculated.
+Specifies how the trendline that smooths out fluctuations in the data is calculated.
 
 
 

--- a/outlook/How-to/Rules/create-a-rule-to-move-specific-e-mails-to-a-folder.md
+++ b/outlook/How-to/Rules/create-a-rule-to-move-specific-e-mails-to-a-folder.md
@@ -9,7 +9,7 @@ localization_priority: Priority
 
 # Create a Rule to Move Specific Emails to a Folder
 
-This topic shows a code sample in Visual Basic for Applicatons (VBA) that uses the  **Rules** object model to create a rule. The code sample uses the **[RuleAction](../../../api/Outlook.RuleAction.md)** and **[RuleCondition](../../../api/Outlook.RuleCondition.md)** objects to specify a rule that moves messages from a specific sender to a specific folder, unless the message contains certain terms in the subject. Note that the code sample assumes that there already exists a folder named "Dan" under the Inbox.
+This topic shows a code sample in Visual Basic for Applications (VBA) that uses the  **Rules** object model to create a rule. The code sample uses the **[RuleAction](../../../api/Outlook.RuleAction.md)** and **[RuleCondition](../../../api/Outlook.RuleCondition.md)** objects to specify a rule that moves messages from a specific sender to a specific folder, unless the message contains certain terms in the subject. Note that the code sample assumes that there already exists a folder named "Dan" under the Inbox.
 
 The following describes the steps used to create the rule:
 


### PR DESCRIPTION

- calcuation -> calculation
- containis -> contains
- asychronous -> asynchronous
- recalcuated -> recalculated
- autmatically -> automatically
- Rrepresents -> Represents
- similiar -> similar
- connction -> connection
- Setc -> Set
- mulitple -> multiple
- properites -> properties
- Ukranian -> Ukrainian
- Convters -> Converters
- repressents -> represents
- fili -> fill
- bacground -> background
- aren?t -> aren't
- cropp -> crop
- defaut -> default
- specifes -> specifies
- Micrososft -> Microsoft
- contstant -> constant
- lislt -> list
- Fomula -> Formula
- conneciton -> connection
- asserver -> as server
- coulmn -> column
- Iindicates -> Indicates
- B?zier -> Bézier
- veritcal -> vertical
- proceedure -> procedure
- mispelled -> misspelled
- thte -> the
- rereshes -> refreshes
- Enghanced -> Enhanced
- commited -> committed
- postive -> positive
- Februray -> February
- speadsheets -> spreadsheets
- Percentatge -> Percentage
- pubish -> publish
- smoothes -> smooths
- behaviour -> behavior
- sustitute -> substitute
- specfying -> specifying
- horizontaol -> horizontal
- retrictions -> restrictions
- Mosiac -> Mosaic
- boundry -> boundary
- workspcae -> workspace
- Represenative -> Representative
- Dispaly -> Display
- Univeral -> Universal
- compatiblity -> compatibility
- invloved -> involved
- delivey -> delivery
- Organizser -> Organizer
- namepsace -> namespace
- Microsft -> Microsoft
- swtich -> switch
- wheter -> whether
- navigaton -> navigation
- Receved -> Received
- Oultook - Outlook
- Fuschsia -> Fuchsia
- Specfies -> Specifies
- Reurns -> Returns
- Applicatons -> Applications
- recomended -> recommended
- recipeints -> recipients
- animiation -> animation
- behaviorce -> behavior
- presentaion -> presentation
- Reamrks -> Remarks
- wtih -> with
- proerty -> property
- Detemines -> Determines
- outine -> outline
- Béziercurves - Bézier curves
- Shap -> Shape
- Determinew -> Determine
- Seqence -> Sequence
- percentageof -> percentage of
- moir? -> moiré
- calandar -> calendar
- calander -> calendar
- seleted -> selected
- precedessors -> predecessors
- specifiy -> specify
- incomple -> incomplete
- hexadicimal -> hexadecimal
- Plannner -> Planner
- Foumula -> Formula
- Resouce -> Resource
- Gnatt -> Gantt
- Fuschia -> Fuchsia
- staus -> status
- follwoing -> following
- deliberable -> deliverable
- Projectis -> Project is
- Sucessor -> Successor
- Cmulative -> Cumulative
- Centeral -> Central
- Indicats -> Indicates
- replacment -> replacement
- reperesents -> represents
- prvious -> previous
- reutrn -> return
- pubication -> publication
- invisble -> invisible
- Brighness -> Brightness
- navigaion -> navigation
- Distibute -> Distribute
- addreses -> addresses
- addtion -> addition
- publicaton -> publication
- programatically -> programmatically
- accelererator -> accelerator
- respondsto -> responds to
- Extensibilty -> Extensibility
- previouly -> previously
- Extensiblity -> Extensibility
- programmtically -> programmatically
- calendary -> calendar
- resutling -> resulting
- objecct -> object
- retreive -> retrieve
- succesfulfully -> successfully
- Shortucts -> Shortcuts
- grpahic -> graphic
- determiones -> determines
- hexidecimal -> hexadecimal
- identifes -> identifies
- visiblity -> visibility
- Visble -> Visible
- execuatable -> executable
- Recordeset -> Recordset
- positon -> position
- Interchage -> Interchange
- Returrns -> Returns
- reveiwers -> reviewers
- evalution -> evaluation
- icone -> icon
- rectanglular -> rectangular
- exising -> existing
- Depcrecated -> Deprecated
- proprerty -> property
- evaulate -> evaluate
- reponds -> responds
- Leter -> Letter
- vailid -> valid
- propertyof -> property of
- insrt -> insert
- membes -> members
- indentifies -> identifies
- protectd -> protected
- conatined -> contained
- tabel -> table
- descirption -> description
- firgures -> figures
- quailty -> quality
- oposite -> opposite
- Tobble -> Toggle