### PR TITLE
chore: Add Markdownlint config

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,23 @@
+{
+    "default": true,
+    "MD002": false,
+    "MD005": false,
+    "MD006": false,
+    "MD007": false,
+    "MD009": false,
+    "MD012": false,
+    "MD013": false,
+    "MD022": false,
+    "MD024": false,
+    "MD026": false,
+    "MD027": false,
+    "MD028": false,
+    "MD029": false,
+    "MD030": false,
+    "MD031": false,
+    "MD032": false,
+    "MD033": false,
+    "MD034": false,
+    "MD036": false,
+    "MD041": false
+}

--- a/Office-Mac/AppleScriptTask.md
+++ b/Office-Mac/AppleScriptTask.md
@@ -44,7 +44,7 @@ The following is an example of a handler.
     end myapplescripthandler
 ```
 
-##What happened to MacScript?
+## What happened to MacScript?
 Earlier versions of Office for Mac implemented a command called **MacScript** that supported inline AppleScripts. Although that command still exists in Office 2016 for Mac, **MacScript** is deprecated. Due to sandbox restrictions, the **MacScript** command cannot invoke other applications, such as Finder, in Office 2016 for Mac. We recommend that you use the **AppleScriptTask** command instead of the **MacScript** command in apps for Office 2016 for Mac.
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Access.Report.OnCurrent.md
+++ b/api/Access.Report.OnCurrent.md
@@ -52,7 +52,6 @@ Private Sub Report_Load()
         Me.OnCurrent = "[Event Procedure]"
 
 End Sub
-		
 ```
 
 The event procedure  **Report_Current()** is automatically called when the **Current** event is fired. This procedure simply collects the values of two of the Report's text boxes and sends them to another procedure for processing.
@@ -76,7 +75,6 @@ Private Sub Report_Current()
         VerifyCreditAvail curPrice, curCreditAvail
 
 End Sub
-		
 ```
 
 The following code example simply processes the two values passed to it.

--- a/api/Excel.Range.RowHeight.md
+++ b/api/Excel.Range.RowHeight.md
@@ -31,7 +31,7 @@ _expression_ A variable that represents a [Range](excel.range-graph-property.md)
 Use the **[AutoFit](Excel.Range.AutoFit.md)** method to set row heights based on the contents of cells.
 
 > [!NOTE]
-> If a merged cell is in the range, **RowHeight** returns **Null** for varied row heights.	Use the **[Height](Excel.Range.Height.md)** property to return the total height of a range of cells.
+> If a merged cell is in the range, **RowHeight** returns **Null** for varied row heights. Use the **[Height](Excel.Range.Height.md)** property to return the total height of a range of cells.
 
 > [!NOTE]
 > When a range contains rows of different heights, **RowHeight** might return the height of the first row or might return **Null**.

--- a/api/Excel.Range.Sort.md
+++ b/api/Excel.Range.Sort.md
@@ -38,7 +38,7 @@ _expression_ A variable that represents a [Range](excel.range-graph-property.md)
 | _Header_|Optional| **xlYesNoGuess**|Specifies whether the first row contains header information. **xlNo** is the default value; specify **xlGuess** if you want Excel to attempt to determine the header.|
 | _OrderCustom_|Optional| **Variant**|Specifies a one-based integer offset into the list of custom sort orders.|
 | _MatchCase_|Optional| **Variant**|Set to **True** to perform a case-sensitive sort, **False** to perform non-case sensitive sort; cannot be used with pivot tables.|
-| _Orientation_|Optional| **xlSortOrientation**|Specifies if the sort should be by row (default) or column. Set **xlSortColumns** value to	1	to sort by column. Set **xlSortRows** value to 2 to sort by row. (This is the default value.) |
+| _Orientation_|Optional| **xlSortOrientation**|Specifies if the sort should be by row (default) or column. Set **xlSortColumns** value to 1 to sort by column. Set **xlSortRows** value to 2 to sort by row. (This is the default value.) |
 | _SortMethod_|Optional| **xlSortMethod**|Specifies the sort method.|
 | _DataOption1_|Optional| **xlSortDataOption**|Specifies how to sort text in the range specified in _Key1_; does not apply to pivot table sorting.|
 | _DataOption2_|Optional| **xlSortDataOption**|Specifies how to sort text in the range specified in  _Key2_; does not apply to pivot table sorting.|

--- a/api/Excel.Range.Text.md
+++ b/api/Excel.Range.Text.md
@@ -35,10 +35,10 @@ This example illustrates the difference between the **Text** and **[Value](Excel
 
 ```vb
 Dim c As Range
-c.Value = 1198.3 	Set c = Worksheets("Sheet1").Range("A1")
-c.NumberFormat = "$#,##0_);($#,##0)" 	c.Value = 1198.3
-MsgBox c.Value 	c.NumberFormat = "$#,##0_);($#,##0)"
-MsgBox c.Text	MsgBox c.Value & " is the value." 'Returns "1198.3 is the value."
+Set c = Worksheets("Sheet1").Range("A1")
+c.NumberFormat = "$#,##0_);($#,##0)"
+c.Value = 1198.3
+MsgBox c.Value & " is the value." 'Returns "1198.3 is the value."
 MsgBox c.Text & " is the text."   'Returns "$1,198 is the text."
 ```
 

--- a/api/PowerPoint.AnimationBehavior.ScaleEffect.md
+++ b/api/PowerPoint.AnimationBehavior.ScaleEffect.md
@@ -55,7 +55,6 @@ Sub ChangeScale()
         .ToX = 100
         .ToY = 100
     End With
-	
 End Sub
 ```
 

--- a/api/PowerPoint.Application.PresentationSave.md
+++ b/api/PowerPoint.Application.PresentationSave.md
@@ -55,7 +55,7 @@ Private Sub App_PresentationSave(ByVal Pres As Presentation)
             & PresName & "'" & " in PowerPoint" _
             & Chr(10) & Chr(13) _
             & " format and HTML version 4.0 format")
-			
+
         .Publish
     End With
 End Sub

--- a/api/PowerPoint.Application.SlideShowNextBuild.md
+++ b/api/PowerPoint.Application.SlideShowNextBuild.md
@@ -65,11 +65,9 @@ Private Sub App_SlideShowNextBuild(ByVal Wn As SlideShowWindow)
 
     End If
 
-	EvtCounter = EvtCounter + 1
+    EvtCounter = EvtCounter + 1
 
 End Sub
-
-	
 ```
 
 

--- a/api/PowerPoint.Comment.Author.md
+++ b/api/PowerPoint.Comment.Author.md
@@ -49,7 +49,6 @@ Sub GetAuthorName()
         MsgBox "This comment was created by " & _
             .Comments(1).Author & " (" & .Comments(1).AuthorInitials & ")."
     End With
-	
 End Sub
 ```
 

--- a/api/PowerPoint.EffectParameters.Relative.md
+++ b/api/PowerPoint.EffectParameters.Relative.md
@@ -65,7 +65,7 @@ Sub AddShapeSetAnimPath()
     MsgBox "Is motion path relative or absolute: " & _
         effDiamond.EffectParameters.Relative & vbCrLf & _
         "0 = Relative, -1 = Absolute"
-		
+
 End Sub
 ```
 

--- a/api/PowerPoint.FileConverter.CanSave.md
+++ b/api/PowerPoint.FileConverter.CanSave.md
@@ -46,10 +46,10 @@ Dim lngSaveFormat As Long
 
 If Application.FileConverters("WordPerfect6x").CanSave = _
         True Then
-		
+
     lngSaveFormat = _
         Application.FileConverters("WordPerfect6x").SaveFormat
-		
+
     ActiveDocument.SaveAs FileName:="C:\Document.wp", _
         FileFormat:=lngSaveFormat
 

--- a/api/PowerPoint.FillFormat.Background.md
+++ b/api/PowerPoint.FillFormat.Background.md
@@ -60,7 +60,7 @@ With ActivePresentation.Slides(1)
             .Fill.PresetGradient _
             msoGradientHorizontal, 1, msoGradientDaybreak
     End With
-	
+
 End With
 ```
 

--- a/api/PowerPoint.FillFormat.TextureType.md
+++ b/api/PowerPoint.FillFormat.TextureType.md
@@ -63,8 +63,6 @@ For Each s In myDocument.Shapes
     End With
 
 Next
-
-	
 ```
 
 

--- a/api/PowerPoint.Selection.ChildShapeRange.md
+++ b/api/PowerPoint.Selection.ChildShapeRange.md
@@ -67,7 +67,7 @@ Sub ChildShapes()
             MsgBox "This is not a range of child shapes."
         End If
     End With
-	
+
 End Sub
 ```
 

--- a/api/PowerPoint.Selection.HasChildShapeRange.md
+++ b/api/PowerPoint.Selection.HasChildShapeRange.md
@@ -50,7 +50,7 @@ Sub ChildShapes()
     With shpCanvas.CanvasItems
         .AddShape msoShapeRectangle, Left:=0, Top:=0, _
             Width:=100, Height:=100
-			
+
         .AddShape msoShapeOval, Left:=0, Top:=50, _
             Width:=100, Height:=100
 
@@ -70,7 +70,7 @@ Sub ChildShapes()
             MsgBox "This is not a range of child shapes."
         End If
     End With
-	
+
 End Sub
 ```
 

--- a/api/PowerPoint.Shape.ParentGroup.md
+++ b/api/PowerPoint.Shape.ParentGroup.md
@@ -47,7 +47,7 @@ Sub ParentGroup()
 
     With sldNewSlide.Shapes
 
-    	.AddShape Type:=msoShapeBalloon, Left:=72, _
+        .AddShape Type:=msoShapeBalloon, Left:=72, _
             Top:=72, Width:=100, Height:=100
 
         .AddShape Type:=msoShapeOval, Left:=110, _

--- a/api/PowerPoint.Shape.ScaleWidth.md
+++ b/api/PowerPoint.Shape.ScaleWidth.md
@@ -68,7 +68,7 @@ For Each s In myDocument.Shapes
     Select Case s.Type
       Case msoEmbeddedOLEObject, msoLinkedOLEObject, _
             msoOLEControlObject, msoLinkedPicture, msoPicture 
-		s.ScaleHeight 1.75, msoTrue
+        s.ScaleHeight 1.75, msoTrue
         s.ScaleWidth 1.75, msoTrue
 
       Case Else

--- a/api/PowerPoint.ShapeRange.Id.md
+++ b/api/PowerPoint.ShapeRange.Id.md
@@ -59,7 +59,7 @@ Sub ShapeID()
 
             Case Else
                 .Fill.ForeColor.RGB = RGB(Red:=0, Green:=0, Blue:=255)
-				
+
         End Select
     End With
 

--- a/api/PowerPoint.SlideShowView.Parent.md
+++ b/api/PowerPoint.SlideShowView.Parent.md
@@ -42,7 +42,7 @@ With myShapes.AddShape(Type:=msoShapeOval, Left:=50, _
 
     .TextRange.Text = "Test text"
     .Parent.Rotation = 45
-	
+
 End With
 ```
 

--- a/api/Word.FillFormat.OneColorGradient.md
+++ b/api/Word.FillFormat.OneColorGradient.md
@@ -41,15 +41,15 @@ This example adds a rectangle with a one-color gradient fill to the active docum
 
 ```vb
 With ActiveDocument
-    
-	.Shapes.AddShape(msoShapeRectangle, _ 
-        90, 90, 90, 80).Fill 
 
-    .ForeColor.RGB = RGB(0, 128, 128) 
+    .Shapes.AddShape(msoShapeRectangle, _
+        90, 90, 90, 80).Fill
 
-    .OneColorGradient msoGradientHorizontal, 1, 1 
+    .ForeColor.RGB = RGB(0, 128, 128)
 
-	End With
+    .OneColorGradient msoGradientHorizontal, 1, 1
+
+End With
 ```
 
 

--- a/excel/Concepts/Excel-Performance/excel-improving-calcuation-performance.md
+++ b/excel/Concepts/Excel-Performance/excel-improving-calcuation-performance.md
@@ -246,11 +246,12 @@ For more information about how the Visual Basic Editor can significantly affect 
     Private Declare PtrSafe Function getFrequency Lib "kernel32" Alias _
         "QueryPerformanceFrequency" (cyFrequency As Currency) As Long
     Private Declare PtrSafe Function getTickCount Lib "kernel32" Alias _
-         "QueryPerformanceCounter" (cyTickCount As Currency) As Long
+        "QueryPerformanceCounter" (cyTickCount As Currency) As Long
 #Else
-    Private Declare Function getFrequency Lib "kernel32" Alias _                                         	"QueryPerformanceFrequency" (cyFrequency As Currency) As Long
+    Private Declare Function getFrequency Lib "kernel32" Alias _
+        "QueryPerformanceFrequency" (cyFrequency As Currency) As Long
     Private Declare Function getTickCount Lib "kernel32" Alias _
-    	"QueryPerformanceCounter" (cyTickCount As Currency) As Long
+        "QueryPerformanceCounter" (cyTickCount As Currency) As Long
 #End If
 Function MicroTimer() As Double
 '


### PR DESCRIPTION
Existing rules that aren't passsing are disabled.
This config will be picked up by VS Code with the MSDocs Authoring Pack (which includes the Markdownlint extension).
To run it from a commandline or as part of the CI:
- Install `npm install -g markdownlint-cli` https://github.com/igorshubovych/markdownlint-cli
- Run `markdownlint "**/*.md"`