### PR TITLE
Notification for missing links

### DIFF
--- a/Language/Reference/User-Interface-Help/visual-basic-language-reference.md
+++ b/Language/Reference/User-Interface-Help/visual-basic-language-reference.md
@@ -18,14 +18,16 @@ Provides documentation about Visual Basic the language: all its methods, propert
 - [Events](../events-visual-basic-for-applications.md)
 - [Functions](../functions-visual-basic-for-applications.md)
 - [Keywords](keywords-by-task.md) 
-- [Methods](../methods-visual-basic-for-applications.md)
+- [Methods](../methods-visual-basic-for-applications.md) <---
 - [Microsoft Forms](reference-microsoft-forms.md)
-- [Object Browser](../object-browser-visual-basic-for-applications.md)
+- [Object Browser](../object-browser-visual-basic-for-applications.md) <---
 - [Objects](../objects-visual-basic-for-applications.md)
 - [Operators](../operators.md)
-- [Properties](../properties-visual-basic-for-applications.md)
+- [Properties](../properties-visual-basic-for-applications.md) <---
 - [Statements](../statements.md)
 - [Visual Basic Add-in Model](visual-basic-add-in-model-reference.md)
+
+![Link missing](https://user-images.githubusercontent.com/26076874/54222203-2f4db500-44b2-11e9-9acb-c766a27cfac8.png)
 
 
 ## See also


### PR DESCRIPTION
Not sure how else to bring attention to this. In the left navigation pane of https://docs.microsoft.com/en-us/office/vba/language/reference/user-interface-help/visual-basic-language-reference there isn't a link for `Methods`, `Object Browser`, or `Properties`.