### PR TITLE
Table.Split is often a better alternative

### DIFF
--- a/api/Word.Selection.SplitTable.md
+++ b/api/Word.Selection.SplitTable.md
@@ -56,4 +56,6 @@ Selection.SplitTable
 
 [Selection Object](Word.Selection.md)
 
+[Table Object](Word.Table.Split.md) . `Split`( `_BeforeRow_` )
+
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]


### PR DESCRIPTION
I may have put my proposed change in the wrong place... apologies if so.

Table.Split() is more flexible and does not suffer the overhead of using Selection; it is a better approach but seems overlooked... for example THIS PAGE was the top result on google for "vba word table.split"