### PR TITLE
Unusual behaviour more clear, & 1 sentence moved

### DIFF
--- a/Language/Reference/User-Interface-Help/vartype-function.md
+++ b/Language/Reference/User-Interface-Help/vartype-function.md
@@ -12,7 +12,7 @@ localization_priority: Normal
 
 # VarType function
 
-Returns an **Integer** indicating the subtype of a [variable](../../Glossary/vbe-glossary.md#variable).
+Returns an **Integer** indicating the subtype of a [variable](../../Glossary/vbe-glossary.md#variable), or the type of an object's default [property](../../Glossary/vbe-glossary.md#property).
 
 ## Syntax
 
@@ -49,23 +49,24 @@ The required _varname_ [argument](../../Glossary/vbe-glossary.md#argument) is a 
 
 ## Remarks
 
-The **VarType** function never returns the value for **vbArray** by itself. It is always added to some other value to indicate an array of a particular type. 
+If an object is passed, & has a default [property](../../Glossary/vbe-glossary.md#property), **VarType**(_object_) returns the type of the object's default property.
 
-The constant **vbVariant** is only returned in conjunction with **vbArray** to indicate that the argument to the **VarType** function is an array of type **Variant**. For example, the value returned for an array of integers is calculated as **vbInteger** + **vbArray**, or 8194. 
+The **VarType** function never returns the value for **vbArray** by itself. It is always added to some other value to indicate an array of a particular type. For example, the value returned for an array of integers is calculated as **vbInteger** + **vbArray**, or 8194. 
 
-If an object has a default [property](../../Glossary/vbe-glossary.md#property), **VarType**(_object_) returns the type of the object's default property.
+The constant **vbVariant** is only returned in conjunction with **vbArray** to indicate that the argument to the **VarType** function is an array of type **Variant**. 
 
 ## Example
 
-This example uses the **VarType** function to determine the subtype of a variable.
+This example uses the **VarType** function to determine the subtypes of different variables, and in one case, the type of an object's default [property](../../Glossary/vbe-glossary.md#property).
 
 ```vb
-Dim IntVar, StrVar, DateVar, MyCheck
+Dim IntVar, StrVar, DateVar, MyCheck, AppVar As Object
 ' Initialize variables.
-IntVar = 459: StrVar = "Hello World": DateVar = #2/12/69# 
+IntVar = 459: StrVar = "Hello World": DateVar = #2/12/69#: Set AppVar = Excel.Application
 MyCheck = VarType(IntVar)    ' Returns 2.
 MyCheck = VarType(DateVar)    ' Returns 7.
 MyCheck = VarType(StrVar)    ' Returns 8.
+MyCheck = VarType(AppVar)    ' Returns 8 (vbString) even though AppVar is an object.
 
 ```
 


### PR DESCRIPTION
### Background
This function's unusual behaviour tripped me up. I ended up posting a [question to StackOverflow](https://stackoverflow.com/questions/55659056/why-is-vbas-vartype-function-saying-this-com-object-is-a-string-object-is-ins) because I didn't expect the unusual behaviour.

I believe the function name, along with what was previously specified in the 'summary' section of the documentation for the function, probably contributed to my not realising that the function had unusual behaviour.

### Changes made
I've made changes to the documentation to make it more clear that the function has unusual behaviour. The 'summary' section before, was not strictly correct (in my opinion), as it gave the impression that this function didn't have any unusual behaviour.

I've also moved one of the sentences in the Remarks section as it seems that the sentence was put into the wrong paragraph.