### PR TITLE
Fixed code example

### DIFF
--- a/api/Outlook.SharingItem.md
+++ b/api/Outlook.SharingItem.md
@@ -31,60 +31,27 @@ The following Visual Basic for Applications (VBA) example creates and displays a
 
 ```vb
 Public Sub CreateTasksSharingItem() 
- 
- 
- 
- Dim oNamespace As NameSpace 
- 
- Dim oFolder As Folder 
- 
- Dim oSharingItem As SharingItem 
- 
- 
- 
  On Error GoTo ErrRoutine 
  
+ Dim mapiNamespace As Outlook.NameSpace 
+ Set mapiNamespace = Outlook.Application.GetNamespace("MAPI") 
  
+ Dim defaultFolder As Outlook.Folder 
+ Set defaultFolder = mapiNamespace.GetDefaultFolder(Outlook.olFolderTasks) 
  
- Set oNamespace = Application.GetNamespace("MAPI") 
+ Dim invitation As Outlook.SharingItem  
+ Set invitation = appNamespace.CreateSharingItem(defaultFolder) 
  
- Set oFolder = oNamespace.GetDefaultFolder(olFolderTasks) 
- 
- Set oSharingItem = oNamespace.CreateSharingItem(oFolder) 
- 
- 
- 
- oSharingItem.Display 
- 
- 
- 
-EndRoutine: 
- 
- On Error GoTo 0 
- 
- Set oSharingItem = Nothing 
- 
- Set oFolder = Nothing 
- 
- Set oNamespace = Nothing 
- 
-Exit Sub 
- 
- 
- 
+ invitation.Display 
+  
+EndRoutine:  
+ Exit Sub 
+  
 ErrRoutine: 
- 
- MsgBox Err.Description, _ 
- 
- vbOKOnly, _ 
- 
- Err.Number &amp; " - " &amp; Err.Source 
- 
- GoTo EndRoutine 
+ MsgBox Err.Description, vbOKOnly, Err.Number &amp; " - " &amp; Err.Source  
+ Resume EndRoutine 
  
 End Sub 
- 
-
 ```
 
 

--- a/api/Outlook.SharingItem.md
+++ b/api/Outlook.SharingItem.md
@@ -36,11 +36,11 @@ Public Sub CreateTasksSharingItem()
  Dim mapiNamespace As Outlook.NameSpace 
  Set mapiNamespace = Outlook.Application.GetNamespace("MAPI") 
  
- Dim defaultFolder As Outlook.Folder 
- Set defaultFolder = mapiNamespace.GetDefaultFolder(Outlook.olFolderTasks) 
+ Dim tasksFolder As Outlook.Folder 
+ Set tasksFolder = mapiNamespace.GetDefaultFolder(Outlook.olFolderTasks) 
  
  Dim invitation As Outlook.SharingItem  
- Set invitation = appNamespace.CreateSharingItem(defaultFolder) 
+ Set invitation = appNamespace.CreateSharingItem(tasksFolder) 
  
  invitation.Display 
   


### PR DESCRIPTION
This `GoTo` jump is harmful and suggests that it's ok to resume from an error-handling subroutine with `GoTo` - it's not. Run-time is still in an error state when execution enters `EndRoutine`, contrary to `Resume EndRoutine`, which correctly clears the error state.
Removed the redundant `Set ... = Nothing` assignments; fully-qualified all Outlook types, to make the dependency explicit (since people are copy-pasting this and then making it late-bound); tightened vertical whitespace, moved variable declarations closer to their usage, and removed the harmful and outdated Systems Hungarian Notation that is heavily discouraged everywhere.