### PR TITLE
Change filename and title

### DIFF
--- a/Language/Reference/User-Interface-Help/remove-method-dictionary.md
+++ b/Language/Reference/User-Interface-Help/remove-method-dictionary.md
@@ -1,5 +1,5 @@
 ---
-title: Remove method (FileSystemObject object)
+title: Remove method (Dictionary)
 keywords: vblr6.chm2181952
 f1_keywords:
 - vblr6.chm2181952
@@ -10,7 +10,7 @@ localization_priority: Normal
 ---
 
 
-# Remove method (FileSystemObject)
+# Remove method (Dictionary)
 
 Removes a key/item pair from a **[Dictionary](dictionary-object.md)** object.
 


### PR DESCRIPTION
As the article describes the Dictionary objects Remove method and not that of the FileSystemObject the title should be updated and the filename changed. I am however uncertain if this is the right way to do this. This is the page that is shown when pressing the edit key in Microsoft Docs so if that relies on the  ms.assetid: dc895fae-17aa-4c51-4a35-8c3d3fd0e6fc or vblr6.chm2181952 I guess this would be Ok.