### PR TITLE
Correct 'comparison operator' section

### DIFF
--- a/Language/Glossary/vbe-glossary.md
+++ b/Language/Glossary/vbe-glossary.md
@@ -177,7 +177,7 @@ Text added to code that explains how the code works. In Visual Basic, a comment 
 
 ## comparison operator
 
-A character or symbol indicating a relationship between two or more values or expressions. These operators include less than (**&lt;**), less than or equal to (**&lt;=**), greater than (**&gt;**), greater than or equal to (**>=**), not equal (**&lt;&gt;**), and equal (**=**). Additional comparison operators include **Is** and **Like**. Note that **Is** and **Like** can't be used as comparison operators in a **Select** **Case** statement.
+Symbol(s) / word indicating a relationship between two or more values or expressions. These operators include less than (**&lt;**), less than or equal to (**&lt;=**), greater than (**&gt;**), greater than or equal to (**>=**), not equal (**&lt;&gt;**), and equal (**=**). Additional comparison operators include **Is** and **Like**. Note that **Is** and **Like** can't be used as comparison operators in a **Select** **Case** statement.
 
 
 ## compiler directive


### PR DESCRIPTION
Operator '<=' is not one symbol but two. As far as I am aware, the comparison operators are either single words, or non-empty strings each consisting of a symbol or multiple symbols. Writing 'character' confuses things. Leaving 'word' out ignores 'Like' operator & 'Is' operator.