### PR TITLE
Elaboration of 'collection' definition

### DIFF
--- a/Language/Glossary/vbe-glossary.md
+++ b/Language/Glossary/vbe-glossary.md
@@ -162,7 +162,7 @@ A pane contained in a code window that is used for entering and editing code. A 
 
 ## collection
 
-An object that contains a set of related objects. An object's position in the collection can change whenever a change occurs in the collection; therefore, the position of any specific object in the collection can vary.
+An object that contains a set of related objects. An object's position in the collection can change whenever a change occurs in the collection; therefore, the position of any specific object in the collection can vary. The [`Collection` object/class](../reference/user-interface-help/collection-object.md) is the standard example of a collection class - instances of the class are collections. Collections must implement a method called `NewEnum` that accepts no arguments, returns an appropriate `IUnknown` object, & has its `VB_UserMemId` attribute set to `-4`.
 
 
 ## command line


### PR DESCRIPTION
#### Actual Change
This PR is simply for elaborating on the glossary definition for collections a little. I felt it wasn't really clear enough before.

This change works in concert with PR #980.

Collections are partly defined in the VBA language specification [here](https://docs.microsoft.com/en-gb/openspecs/microsoft_general_purpose_programming_languages/ms-vbal/b132463a-fd25-4143-8fc7-a443930e0651).

Below is a pertinent excerpt from the spec.:

> - If the data value of <collection> is not an array:
> 
>     + The data value of <collection> must be an object-reference to an external object that supports an implementation-defined enumeration interface.  ...
> ..........


#### Further Improvements
Note that such custom collection classes appear to be referred to as 'strongly typed collection classes'. See [here](https://github.com/rubberduck-vba/Rubberduck/issues/4236) & [here](https://productivebytes.blogspot.com/2012/04/how-to-create-strongly-typed-collection.html) for examples of this. If this is the right terminology, it might be best to use it in the VBA documentation.

It might be best to give more details. For example, if all collection classes should implement a named interface, what is the interface name and what are the interface details in summary?

---

#### History
Spawned from ISSUE #977.

#### Please Note
Note that other commit that used to be in 'this patch', has now been placed in another patch according to the direction given by **@Linda-Editor**. See PR #980 for other commit which is related to this PR. Viewing both PRs together might be beneficial.