### PR TITLE
Code:'+' used when '&' should have been used

### DIFF
--- a/api/Access.ComboBox.md
+++ b/api/Access.ComboBox.md
@@ -49,11 +49,11 @@ Private Sub cmdSearch_Click()
     On Error GoTo 0
     
     vWhere = Null
-    vWhere = vWhere &amp; " AND [PymtTypeID]=" + Me.cboPaymentTypes
-    vWhere = vWhere &amp; " AND [RefundTypeID]=" + Me.cboRefundType
-    vWhere = vWhere &amp; " AND [RefundCDMID]=" + Me.cboRefundCDM
-    vWhere = vWhere &amp; " AND [RefundOptionID]=" + Me.cboRefundOption
-    vWhere = vWhere &amp; " AND [RefundCodeID]=" + Me.cboRefundCode
+    vWhere = vWhere &amp; " AND [PymtTypeID]=" & Me.cboPaymentTypes
+    vWhere = vWhere &amp; " AND [RefundTypeID]=" & Me.cboRefundType
+    vWhere = vWhere &amp; " AND [RefundCDMID]=" & Me.cboRefundCDM
+    vWhere = vWhere &amp; " AND [RefundOptionID]=" & Me.cboRefundOption
+    vWhere = vWhere &amp; " AND [RefundCodeID]=" & Me.cboRefundCode
     
     If Nz(vWhere, "") = "" Then
         MsgBox "There are no search criteria selected." &amp; vbCrLf &amp; vbCrLf &amp; _


### PR DESCRIPTION
@Linda-Editor asked me to investigate the use of the '&amp;' text in the code example here. Have discovered that it is a mistake. See ISSUE #1029 for more info.

Whilst doing the investigation, I discovered another issue with the code. The operator '+' has been used when '&' should have been used. This file commit / PR is in respect to this latter issue. I decided to PR this issue as @Linda-Editor may make a coding mistake if she manually makes this change - it doesn't appear that she is that familiar with coding.