### PR TITLE
Fix for mistakes in code examples found when investigating ISSUE #1029

### DIFF
--- a/api/Access.ComboBox.md
+++ b/api/Access.ComboBox.md
@@ -114,13 +114,13 @@ Private Sub cboMainCategory_NotInList(NewData As String, Response As Integer)
     On Error GoTo Error_Handler
     Dim intAnswer As Integer
     intAnswer = MsgBox("""" &amp; NewData &amp; """ is not an approved category. " &amp; vbcrlf _
-        &amp; "Do you want to add it now?" _ vbYesNo + vbQuestion, "Invalid Category")
+        &amp; "Do you want to add it now?", vbYesNo + vbQuestion, "Invalid Category")
 
     Select Case intAnswer
         Case vbYes
             DoCmd.SetWarnings False
-            DoCmd.RunSQL "INSERT INTO tlkpCategoryNotInList (Category) "
-                &amp; _ "Select """ &amp; NewData &amp; """;"
+            DoCmd.RunSQL "INSERT INTO tlkpCategoryNotInList (Category) " &amp; _ 
+                         "Select """ &amp; NewData &amp; """;"
             DoCmd.SetWarnings True
             Response = acDataErrAdded
         Case vbNo
@@ -135,7 +135,7 @@ Private Sub cboMainCategory_NotInList(NewData As String, Response As Integer)
         Exit Sub
 
     Error_Handler:
-        MsgBox Err.Number &amp; ", " &amp; Error Description
+        MsgBox Err.Number &amp; ", " &amp; Err.Description
         Resume Exit_Procedure
         Resume
 

--- a/api/Access.ComboBox.md
+++ b/api/Access.ComboBox.md
@@ -49,11 +49,11 @@ Private Sub cmdSearch_Click()
     On Error GoTo 0
     
     vWhere = Null
-    vWhere = vWhere &amp; " AND [PymtTypeID]=" + Me.cboPaymentTypes
-    vWhere = vWhere &amp; " AND [RefundTypeID]=" + Me.cboRefundType
-    vWhere = vWhere &amp; " AND [RefundCDMID]=" + Me.cboRefundCDM
-    vWhere = vWhere &amp; " AND [RefundOptionID]=" + Me.cboRefundOption
-    vWhere = vWhere &amp; " AND [RefundCodeID]=" + Me.cboRefundCode
+    vWhere = vWhere &amp; " AND [PymtTypeID]=" & Me.cboPaymentTypes
+    vWhere = vWhere &amp; " AND [RefundTypeID]=" & Me.cboRefundType
+    vWhere = vWhere &amp; " AND [RefundCDMID]=" & Me.cboRefundCDM
+    vWhere = vWhere &amp; " AND [RefundOptionID]=" & Me.cboRefundOption
+    vWhere = vWhere &amp; " AND [RefundCodeID]=" & Me.cboRefundCode
     
     If Nz(vWhere, "") = "" Then
         MsgBox "There are no search criteria selected." &amp; vbCrLf &amp; vbCrLf &amp; _

--- a/api/Access.CurrentProject.md
+++ b/api/Access.CurrentProject.md
@@ -72,15 +72,15 @@ Sub GetAccessData()
  Dim strDB As String 
  Dim strReportName As String 
  
- strDB = "C:\Program Files\Microsoft "_ 
- &amp; "Office\Office11\Samples\Northwind.mdb" 
+ strDB = "C:\Program Files\Microsoft " _ 
+          &amp; "Office\Office11\Samples\Northwind.mdb" 
  strReportName = InputBox("Enter name of report to be verified", _ 
- "Report Verification") 
+                          "Report Verification") 
  VerifyAccessReport strDB, strReportName 
 End Sub 
  
 Sub VerifyAccessReport(strDB As String, _ 
- strReportName As String) 
+                       strReportName As String) 
  ' Return reference to Microsoft Access 
  ' Application object. 
  Set appAccess = New Access.Application 
@@ -88,15 +88,15 @@ Sub VerifyAccessReport(strDB As String, _
  appAccess.OpenCurrentDatabase strDB 
  ' Verify report exists. 
  On Error Goto ErrorHandler 
- appAccess.CurrentProject.AllReports(strReportName) 
+ IsObject appAccess.CurrentProject.AllReports(strReportName) 
  MsgBox "Report " &amp; strReportName &amp; _ 
- " verified within Northwind database." 
+        " verified within " & appAccess.CurrentProject.Name & " database."
  appAccess.CloseCurrentDatabase 
  Set appAccess = Nothing 
 Exit Sub 
 ErrorHandler: 
  MsgBox "Report " &amp; strReportName &amp; _ 
- " does not exist within Northwind database." 
+        " does not exist within " & appAccess.CurrentProject.Name & " database."
  appAccess.CloseCurrentDatabase 
  Set appAccess = Nothing 
 End Sub


### PR DESCRIPTION
@Linda-Editor asked me to investigate the use of the '\&amp;' text in a couple of code-example extracts. Have discovered that such use is a mistake. See ISSUE #1029 for more info.

Whilst doing the investigation, I discovered other issues in related code examples. This PR is in respect to fixing these other issues.