### PR TITLE
Adds a note about modern Office add-ins

### DIFF
--- a/Language/Concepts/Getting-Started/calling-sub-and-function-procedures.md
+++ b/Language/Concepts/Getting-Started/calling-sub-and-function-procedures.md
@@ -5,7 +5,7 @@ f1_keywords:
 - vbcn6.chm1076673
 ms.prod: office
 ms.assetid: 17a9dec1-d8f2-584c-324f-164b4f7b156f
-ms.date: 12/21/2018
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
@@ -13,6 +13,8 @@ localization_priority: Priority
 # Calling Sub and Function procedures
 
 To call a **[Sub](../../reference/user-interface-help/sub-statement.md)** procedure from another [procedure](../../Glossary/vbe-glossary.md#procedure), type the name of the procedure and include values for any required [arguments](../../Glossary/vbe-glossary.md#argument). The **[Call](../../reference/user-interface-help/call-statement.md)** statement is not required, but if you use it, you must enclose any arguments in parentheses.
+
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 You can use a **Sub** procedure to organize other procedures so they are easier to understand and debug. In the following example, the **Sub** procedure `Main` calls the **Sub** procedure `MultiBeep`, passing the value 56 for its argument. 
 

--- a/Language/Reference/User-Interface-Help/automation-error-error-440.md
+++ b/Language/Reference/User-Interface-Help/automation-error-error-440.md
@@ -5,7 +5,7 @@ f1_keywords:
 - vblr6.chm1000440
 ms.prod: office
 ms.assetid: 7b4be799-038b-8f70-d893-848fcfa92993
-ms.date: 06/08/2017
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
@@ -14,7 +14,7 @@ localization_priority: Priority
 
 When you access [Automation objects](../../Glossary/vbe-glossary.md#automation-object), specific types of errors can occur. This error has the following possible causes and solutions:
 
-
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 - An error occurred while executing a [method](../../Glossary/vbe-glossary.md#method) or getting or setting a [property](../../Glossary/vbe-glossary.md#property) of an [object variable](../../Glossary/vbe-glossary.md#object-variable). The error was reported by the application that created the object.
     

--- a/Language/Reference/User-Interface-Help/can-t-find-project-or-library.md
+++ b/Language/Reference/User-Interface-Help/can-t-find-project-or-library.md
@@ -5,14 +5,18 @@ f1_keywords:
 - vblr6.chm1011094
 ms.prod: office
 ms.assetid: 078ae060-a90b-e992-2cfb-34ee6b003098
-ms.date: 06/08/2017
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
 
 # Can't find project or library
 
-You can't run your code until all missing references are resolved. This error has the following causes and solutions:
+You can't run your code until all missing references are resolved.
+
+[!include[Add-ins note](../../../includes/addinsnote.md)]
+
+This error has the following causes and solutions:
 
 
 

--- a/Language/Reference/User-Interface-Help/compile-error-in-hidden-modulemodule-name.md
+++ b/Language/Reference/User-Interface-Help/compile-error-in-hidden-modulemodule-name.md
@@ -5,7 +5,7 @@ f1_keywords:
 - vblr6.chm1011113
 ms.prod: office
 ms.assetid: 14deea0e-46ae-bcbd-b1c4-2363c90365f9
-ms.date: 06/08/2017
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 

--- a/Language/Reference/User-Interface-Help/compile-error-in-hidden-modulemodule-name.md
+++ b/Language/Reference/User-Interface-Help/compile-error-in-hidden-modulemodule-name.md
@@ -14,6 +14,8 @@ localization_priority: Priority
 
 A protected [module](../../Glossary/vbe-glossary.md#module) contains a compilation error. Because the error is in a protected module it cannot be displayed.
 
+[!include[Add-ins note](../../../includes/addinsnote.md)]
+
 This error commonly occurs when code is incompatible with the version or architecture of this application (for example, code in a document targets 32-bit Microsoft Office applications but it is attempting to run on 64-bit Office).
 
  This error has the following cause and solution:

--- a/Language/Reference/User-Interface-Help/format-function-visual-basic-for-applications.md
+++ b/Language/Reference/User-Interface-Help/format-function-visual-basic-for-applications.md
@@ -5,7 +5,7 @@ f1_keywords:
 - vblr6.chm1008925
 ms.prod: office
 ms.assetid: 67f60abf-0c77-49ec-924f-74ae6eb96ea8
-ms.date: 12/12/2018
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
@@ -13,6 +13,8 @@ localization_priority: Priority
 # Format function
 
 Returns a **Variant (String)** containing an [expression](../../Glossary/vbe-glossary.md#expression) formatted according to instructions contained in a format expression.
+
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 ## Syntax
 

--- a/Language/Reference/User-Interface-Help/instr-function.md
+++ b/Language/Reference/User-Interface-Help/instr-function.md
@@ -5,7 +5,7 @@ f1_keywords:
 - vblr6.chm1008946
 ms.prod: office
 ms.assetid: d83b314a-e77c-fc18-0744-266f982a82b7
-ms.date: 12/13/2018
+ms.date: 08/14/2019
 localization_priority: Normal
 ---
 
@@ -13,6 +13,8 @@ localization_priority: Normal
 # InStr function
 
 Returns a **Variant** (**Long**) specifying the position of the first occurrence of one string within another.
+
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 ## Syntax
 

--- a/Language/Reference/User-Interface-Help/msgbox-function.md
+++ b/Language/Reference/User-Interface-Help/msgbox-function.md
@@ -5,13 +5,15 @@ f1_keywords:
 - vblr6.chm1008978
 ms.prod: office
 ms.assetid: 715595a7-4286-a0cb-dec9-2d2e79bda102
-ms.date: 12/13/2018
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
 # MsgBox function
 
 Displays a message in a dialog box, waits for the user to click a button, and returns an **Integer** indicating which button the user clicked.
+
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 ## Syntax
 

--- a/Language/Reference/User-Interface-Help/object-variable-not-set-error-91.md
+++ b/Language/Reference/User-Interface-Help/object-variable-not-set-error-91.md
@@ -5,14 +5,18 @@ f1_keywords:
 - vblr6.chm1000091
 ms.prod: office
 ms.assetid: db8be8b0-9437-d53e-18b9-1d646b40ea66
-ms.date: 06/08/2017
+ms.date: 08/14/2019
 localization_priority: Normal
 ---
 
 
 # Object variable not set (Error 91)
 
-There are two steps to creating an [object variable](../../Glossary/vbe-glossary.md#object-variable). First you must declare the object variable. Then you must assign a valid reference to the object variable using the **Set** statement. Similarly, a **With...End With** block must be initialized by executing the **With** statement entry point. This error has the following causes and solutions:
+There are two steps to creating an [object variable](../../Glossary/vbe-glossary.md#object-variable). First you must declare the object variable. Then you must assign a valid reference to the object variable using the **Set** statement.
+
+[!include[Add-ins note](../includes/addinsnote.md)]
+
+Similarly, a **With...End With** block must be initialized by executing the **With** statement entry point. This error has the following causes and solutions:
 
 - You attempted to use an object variable that isn't yet referencing a valid object.
     

--- a/Language/Reference/User-Interface-Help/object-variable-not-set-error-91.md
+++ b/Language/Reference/User-Interface-Help/object-variable-not-set-error-91.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 There are two steps to creating an [object variable](../../Glossary/vbe-glossary.md#object-variable). First you must declare the object variable. Then you must assign a valid reference to the object variable using the **Set** statement.
 
-[!include[Add-ins note](../includes/addinsnote.md)]
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 Similarly, a **With...End With** block must be initialized by executing the **With** statement entry point. This error has the following causes and solutions:
 

--- a/Language/Reference/User-Interface-Help/subscript-out-of-range-error-9.md
+++ b/Language/Reference/User-Interface-Help/subscript-out-of-range-error-9.md
@@ -33,3 +33,4 @@ Elements of [arrays](../../Glossary/vbe-glossary.md#array) and members of [colle
 For additional information, select the item in question and press F1 (in Windows) or HELP (on the Macintosh).
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]
+[!include[Add-ins note](../../../includes/addinsnote.md)]

--- a/Language/Reference/User-Interface-Help/type-mismatch-error-13.md
+++ b/Language/Reference/User-Interface-Help/type-mismatch-error-13.md
@@ -5,14 +5,18 @@ f1_keywords:
 - vblr6.chm1011290
 ms.prod: office
 ms.assetid: cbc7e902-b468-c335-5620-1ff9a2026b9b
-ms.date: 06/08/2017
+ms.date: 08/14/2019
 localization_priority: Normal
 ---
 
 
 # Type mismatch (Error 13)
 
-Visual Basic is able to convert and coerce many values to accomplish [data type](../../Glossary/vbe-glossary.md#data-type) assignments that weren't possible in earlier versions. However, this error can still occur and has the following causes and solutions:
+Visual Basic is able to convert and coerce many values to accomplish [data type](../../Glossary/vbe-glossary.md#data-type) assignments that weren't possible in earlier versions.
+
+[!include[Add-ins note](../../../includes/addinsnote.md)]
+
+However, this error can still occur and has the following causes and solutions:
 
 - **Cause:** The [variable](../../Glossary/vbe-glossary.md#variable) or [property](../../Glossary/vbe-glossary.md#property) isn't of the correct type. For example, a variable that requires an integer value can't accept a string value unless the whole string can be recognized as an integer.
     

--- a/Language/Reference/User-Interface-Help/visual-basic-conceptual-topics.md
+++ b/Language/Reference/User-Interface-Help/visual-basic-conceptual-topics.md
@@ -2,7 +2,7 @@
 title: Visual Basic conceptual topics
 ms.prod: office
 ms.assetid: 2628d596-7a4a-4a4d-89df-8f1faabd7d49
-ms.date: 11/21/2018
+ms.date: 08/14/2019
 localization_priority: Normal
 ---
 
@@ -10,6 +10,8 @@ localization_priority: Normal
 # Visual Basic conceptual topics
 
 Information to help you get started with Visual Basic programming.
+
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 - [64-bit Visual Basic for Applications overview](../../Concepts/Getting-Started/64-bit-visual-basic-for-applications-overview.md)
 - [Avoid naming conflicts](../../Concepts/Getting-Started/avoiding-naming-conflicts.md)

--- a/Language/Reference/User-Interface-Help/visual-basic-how-to-topics.md
+++ b/Language/Reference/User-Interface-Help/visual-basic-how-to-topics.md
@@ -2,7 +2,7 @@
 title: Visual Basic how-to topics
 ms.prod: office
 ms.assetid: ca0cc8c7-69eb-45a3-aefc-5df69d64cd22
-ms.date: 11/21/2018
+ms.date: 08/14/2019
 localization_priority: Normal
 ---
 
@@ -10,6 +10,8 @@ localization_priority: Normal
 # Visual Basic how-to topics
 
 Describes useful common procedures (for example, how to use the **Object Browser** or how to set Visual Basic Environment options).
+
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 - [Add a watch expression](../../Concepts/Forms/add-a-watch-expression.md)
 - [Check or add an Object Library Reference](../../How-to/check-or-add-an-object-library-reference.md)

--- a/Language/Reference/User-Interface-Help/visual-basic-language-reference.md
+++ b/Language/Reference/User-Interface-Help/visual-basic-language-reference.md
@@ -2,7 +2,7 @@
 title: Visual Basic language reference
 ms.prod: office
 ms.assetid: ea3d048c-6984-42a0-8a27-27172aa69620
-ms.date: 03/13/2019 
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
@@ -10,6 +10,8 @@ localization_priority: Priority
 # Visual Basic language reference
 
 Provides documentation about Visual Basic the language: all its methods, properties, statements, functions, operators, and objects. 
+
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 - [Character sets](../character-sets.md)
 - [Constants](../constants-visual-basic-for-applications.md)

--- a/Language/Reference/User-Interface-Help/visual-basic-user-interface-help.md
+++ b/Language/Reference/User-Interface-Help/visual-basic-user-interface-help.md
@@ -2,7 +2,7 @@
 title: Visual Basic user interface help
 ms.prod: office
 ms.assetid: ceb37836-24b1-4903-bfac-e3e2ad553867
-ms.date: 11/26/2018
+ms.date: 08/14/2019
 localization_priority: Normal
 ---
 
@@ -10,6 +10,8 @@ localization_priority: Normal
 # Visual Basic user interface help
 
 This section also includes user interface elements of the Visual Basic Editor, such as commands, dialog boxes, windows, and toolbars.
+
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 - [Dialog boxes](../dialog-boxes.md)
 - [Error messages](../error-messages.md)

--- a/Library-Reference/Concepts/getting-started-with-vba-in-office.md
+++ b/Library-Reference/Concepts/getting-started-with-vba-in-office.md
@@ -21,6 +21,8 @@ Beyond the power of scripting VBA to accelerate every-day tasks, you can use VBA
 
 This article explores some of the primary reasons to leverage the power of VBA programming. It explores the VBA language and the out-of-the-box tools that you can use to work with your solutions. Finally, it includes some tips and ways to avoid some common programming frustrations and missteps.
 
+[!include[Add-ins note](../../includes/addinsnote.md)]
+
 ## When to use VBA and why
 
 There are several principal reasons to consider VBA programming in Office.

--- a/Library-Reference/Concepts/getting-started-with-vba-in-office.md
+++ b/Library-Reference/Concepts/getting-started-with-vba-in-office.md
@@ -2,7 +2,7 @@
 title: Getting started with VBA in Office
 ms.prod: office
 ms.assetid: 7208a87a-a567-41d9-af5b-0df3884c58d9
-ms.date: 01/02/2019
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 

--- a/access/Concepts/Miscellaneous/the-changes-you-requested-to-the-table-were-not-successful-because-they-would-cr.md
+++ b/access/Concepts/Miscellaneous/the-changes-you-requested-to-the-table-were-not-successful-because-they-would-cr.md
@@ -11,7 +11,7 @@ localization_priority: Priority
 
 # The changes you requested to the table were not successful because they would create duplicate values in the index, primary key, or relationship. (Error 3022)
 
-[!include[Add-ins note](../includes/addinsnote.md)]
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 **Applies to:** Access 2013 | Access 2016
 

--- a/access/Concepts/Miscellaneous/the-changes-you-requested-to-the-table-were-not-successful-because-they-would-cr.md
+++ b/access/Concepts/Miscellaneous/the-changes-you-requested-to-the-table-were-not-successful-because-they-would-cr.md
@@ -5,13 +5,13 @@ f1_keywords:
 - jeterr40.chm5003022
 ms.prod: access
 ms.assetid: 36382cfd-740c-61e7-b55c-ab8a8ac5fab0
-ms.date: 06/08/2017
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
 # The changes you requested to the table were not successful because they would create duplicate values in the index, primary key, or relationship. (Error 3022)
 
-  
+[!include[Add-ins note](../includes/addinsnote.md)]
 
 **Applies to:** Access 2013 | Access 2016
 

--- a/access/Concepts/Miscellaneous/the-field-name-cannot-contain-a-null-value-because-the-required-property-for-thi.md
+++ b/access/Concepts/Miscellaneous/the-field-name-cannot-contain-a-null-value-because-the-required-property-for-thi.md
@@ -5,14 +5,14 @@ f1_keywords:
 - jeterr40.chm5003314
 ms.prod: access
 ms.assetid: 451a9b22-e0ec-cb43-92d4-2f010086802c
-ms.date: 06/08/2017
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
 
 # The field <name> cannot contain a Null value because the Required property for this field is set to True. Enter a value in this field. (Error 3314)
 
-  
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 **Applies to:** Access 2013 | Access 2016
 

--- a/access/Concepts/Miscellaneous/unexpected-error-from-external-database-driver-error-numbererror-3275.md
+++ b/access/Concepts/Miscellaneous/unexpected-error-from-external-database-driver-error-numbererror-3275.md
@@ -5,14 +5,14 @@ f1_keywords:
 - jeterr40.chm5003275
 ms.prod: access
 ms.assetid: 430cfbe5-0071-32e3-7d95-50a2f3c85870
-ms.date: 06/08/2017
+ms.date: 08/14/2019
 localization_priority: Normal
 ---
 
 
 # Unexpected error from external database driver <error number>. (Error 3275)
 
-  
+[!include[Add-ins note](../../../includes/addinsnote.md)]
 
 **Applies to:** Access 2013 | Access 2016
 

--- a/api/Excel.Range(object).md
+++ b/api/Excel.Range(object).md
@@ -7,7 +7,7 @@ ms.prod: excel
 api_name:
 - Excel.Range
 ms.assetid: b8207778-0dcc-4570-1234-f130532cc8cd
-ms.date: 05/15/2019
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
@@ -15,6 +15,8 @@ localization_priority: Priority
 # Range object (Excel)
 
 Represents a cell, a row, a column, a selection of cells containing one or more contiguous blocks of cells, or a 3D range.
+
+[!include[Add-ins note](../includes/addinsnote.md)]
 
 ## Remarks
 

--- a/api/Excel.Range.Cells.md
+++ b/api/Excel.Range.Cells.md
@@ -7,7 +7,7 @@ ms.prod: excel
 api_name:
 - Excel.Range.Cells
 ms.assetid: 32a6ecc7-2366-2cec-1feb-0966241a435d
-ms.date: 05/10/2019
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
@@ -15,6 +15,8 @@ localization_priority: Priority
 # Range.Cells property (Excel)
 
 Returns a **Range** object that represents the cells in the specified range.
+
+[!include[Add-ins note](../includes/addinsnote.md)]
 
 
 ## Syntax

--- a/api/Excel.Range.Copy.md
+++ b/api/Excel.Range.Copy.md
@@ -7,7 +7,7 @@ ms.prod: excel
 api_name:
 - Excel.Range.Copy
 ms.assetid: ac5207ac-6be5-3c7e-2c61-67954a59e9df
-ms.date: 05/10/2019
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 
@@ -15,6 +15,8 @@ localization_priority: Priority
 # Range.Copy method (Excel)
 
 Copies the range to the specified range or to the Clipboard.
+
+[!include[Add-ins note](../includes/addinsnote.md)]
 
 
 ## Syntax

--- a/api/Excel.Range.Find.md
+++ b/api/Excel.Range.Find.md
@@ -16,6 +16,8 @@ localization_priority: Priority
 
 Finds specific information in a range.
 
+[!include[Add-ins note](../includes/addinsnote.md)]
+
 ## Syntax
 
 _expression_.**Find** (_What_, _After_, _LookIn_, _LookAt_, _SearchOrder_, _SearchDirection_, _MatchCase_, _MatchByte_, _SearchFormat_)

--- a/api/Excel.Range.Find.md
+++ b/api/Excel.Range.Find.md
@@ -7,7 +7,7 @@ ms.prod: excel
 api_name:
 - Excel.Range.Find
 ms.assetid: d9585265-8164-cb4d-a9e3-262f6e06b6b8
-ms.date: 06/06/2019
+ms.date: 08/14/2019
 localization_priority: Priority
 ---
 

--- a/api/Excel.Workbook.SaveAs.md
+++ b/api/Excel.Workbook.SaveAs.md
@@ -7,7 +7,7 @@ ms.prod: excel
 api_name:
 - Excel.Workbook.SaveAs
 ms.assetid: fbc3ce55-27a3-aa07-3fdb-77b0d611e394
-ms.date: 05/29/2019
+ms.date: 08/14/2019
 localization_priority: Normal
 ---
 
@@ -15,6 +15,8 @@ localization_priority: Normal
 # Workbook.SaveAs method (Excel)
 
 Saves changes to the workbook in a different file.
+
+[!include[Add-ins note](../includes/addinsnote.md)]
 
 
 ## Syntax

--- a/api/Excel.Workbooks.Open.md
+++ b/api/Excel.Workbooks.Open.md
@@ -7,7 +7,7 @@ ms.prod: excel
 api_name:
 - Excel.Workbooks.Open
 ms.assetid: 1d1c3fca-ae1a-0a91-65a2-6f3f0fb308a0
-ms.date: 05/18/2019
+ms.date: 08/14/2019
 localization_priority: Normal
 ---
 
@@ -15,6 +15,8 @@ localization_priority: Normal
 # Workbooks.Open method (Excel)
 
 Opens a workbook.
+
+[!include[Add-ins note](../includes/addinsnote.md)]
 
 
 ## Syntax

--- a/articles/feedback-support.md
+++ b/articles/feedback-support.md
@@ -1,7 +1,7 @@
 ---
 title: Office VBA support and feedback
 ms.prod: office
-ms.date: 01/16/2019
+ms.date: 08/14/2019
 ---
 
 # Office VBA support and feedback

--- a/articles/feedback-support.md
+++ b/articles/feedback-support.md
@@ -8,6 +8,8 @@ ms.date: 01/16/2019
 
 Have questions or feedback about Office VBA or this documentation? The following list provides guidance about the ways you can receive support and provide feedback.
 
+[!include[Add-ins note](../includes/addinsnote.md)]
+
 <br/>
 
 | Subject | Guidance |

--- a/includes/addinsnote.md
+++ b/includes/addinsnote.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> Interested in developing solutions that extend the Office experience across [multiple platforms](https://dev.office.com/add-in-availability)? Check out the new [Office Add-ins model](https://dev.office.com/docs/add-ins/overview/office-add-ins). Office Add-ins have a small footprint compared to VSTO Add-ins and solutions, and you can build them by using almost any web programming technology, such as HTML5, JavaScript, CSS3, and XML.


### PR DESCRIPTION
I work on the docs for Office Add-ins (https://github.com/OfficeDev/office-js-docs-pr) and by studying web analytics data, we think that adding a note to select high-trafficked pages of this docset will drive customers to a more modern add-ins solution, if they want that. Data from our customer surveys and interviews show that most people who have used previous versions of related Office technology do not discover the modern Office Add-in docs, so we are trying to drive discoverability. Happy to answer more questions on this if you have them.