### PR TITLE
Update Word.Documents.CheckOut.md

### DIFF
--- a/api/Word.Documents.CheckOut.md
+++ b/api/Word.Documents.CheckOut.md
@@ -21,7 +21,7 @@ Copies a specified document from a server to a local computer for editing.
 
 _expression_.**CheckOut** (_FileName_)
 
-_expression_ Required. A variable that represents a **[Document](Word.Document.md)** object.
+_expression_ Required. A variable that represents a **[Documents](Word.documents.md)** object.
 
 
 ## Parameters


### PR DESCRIPTION
It falsely says expression represents a Document object, but it actually represents a Documents object.