### PR TITLE
Update Excel.XlCopyPictureFormat.md

### DIFF
--- a/api/Excel.XlCopyPictureFormat.md
+++ b/api/Excel.XlCopyPictureFormat.md
@@ -17,7 +17,7 @@ Specifies the format of the picture being copied.
 
 |Name|Value|Description|
 |:-----|:-----|:-----|
-| **xlBitmap**|2|Bitmap (.bmp, .jpg, .gif).|
-| **xlPicture**|-4147|Drawn picture (.png, .wmf, .mix).|
+| **xlBitmap**|2|Picture copied in bitmap (raster) format: bmp, jpg, gif, png.
+| **xlPicture**|-4147|Picture copied in vector format: emf, wmf.|
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]


### PR DESCRIPTION
Update verbiage per Excel MVP Jon Peltier:

I came across a confusing description in this docs page. Perhaps you could forward it as appropriate.

https://docs.microsoft.com/en-us/office/vba/api/excel.xlcopypictureformat  

 


xlBitmap means copied in bitmap (raster) format: bmp, jpg, gif, png.

xlPicture means copied in vector format: emf, wmf, but not png. "Drawn picture" is meaningless.