### PR TITLE
correct the hyperlink in [Range]

### DIFF
--- a/word/Concepts/Working-with-Word/working-with-range-objects.md
+++ b/word/Concepts/Working-with-Word/working-with-range-objects.md
@@ -84,7 +84,7 @@ Sub NewRange()
 End Sub
 ```
 
-For additional information and examples, see the **[Range](../../../api/Word.Range.CheckSynonyms.md)** method.
+For additional information and examples, see the **[Range](../../../api/word.document.range.md)** method.
 
 
 ## Using the Range property


### PR DESCRIPTION
the hyperlink of the "Range" in the sentence "For additional information and examples, see the **[Range]" is not proper.
It should link to the page "https://docs.microsoft.com/zh-tw/office/vba/api/word.document.range"