### PR TITLE
Enhancements around Range.Item

### DIFF
--- a/api/Excel.Range(object).md
+++ b/api/Excel.Range(object).md
@@ -20,10 +20,14 @@ Represents a cell, a row, a column, a selection of cells containing one or more 
 
 ## Remarks
 
+The default member of **Range** forwards calls without parameters to the **[Value](Excel.Range.Value)** property and calls with parameters to the **[Item](Excel.Range.Item)** member. Accordingly, `someRange = someOtherRange` is equivalent to `someRange.Value = someOtherRange.Value`, `someRange(1)` to `someRange.Item(1)` and `someRange(1,1)` to `someRange.Item(1,1)`.
+
 The following properties and methods for returning a **Range** object are described in the **Example** section:
 
 - **[Range](Excel.Worksheet.Range.md)** and **[Cells](Excel.Worksheet.Cells.md)** properties of the **Worksheet** object
 - **[Range](excel.range.range.md)** and **[Cells](excel.range.cells.md)** properties of the **Range** object   
+- **[Rows](Excel.Worksheet.Rows.md)** and **[Columns](Excel.Worksheet.Columns.md)** properties of the **Worksheet** object
+- **[Rows](Excel.Range.Rows.md)** and **[Columns](Excel.Range.Columns.md)** properties of the **Range** object  
 - **[Offset](Excel.Range.Offset.md)** property of the **Range** object  
 - **[Union](Excel.Application.Union.md)** method of the **Application** object
 
@@ -60,10 +64,13 @@ Worksheets(1).Range("Criteria").ClearContents
 
 <br/>
 
-Use **Cells** (_row_, _column_), where _row_ is the row index and _column_ is the column index, to return a single cell. The following example sets the value of cell A1 to 24.
+Use **Cells** on a worksheet to obtain a range consisting all single cells on the worksheet. You can access single cells via **Item**(_row_, _column_), where _row_ is the row index and _column_ is the column index. 
+**Item** can be omitted since the call is forwarded to it by the default member of **Range**. 
+The following example sets the value of cell A1 to 24 and of cell B1 to 42 on the first sheet of the active workbook.
 
 ```vb
 Worksheets(1).Cells(1, 1).Value = 24
+Worksheets(1).Cells.Item(1, 2).Value = 42
 ```
 
 <br/>
@@ -95,10 +102,14 @@ End Sub
 
 <br/>
 
-Use_expression_.**Cells** (_row_, _column_), where _expression_ is an expression that returns a **Range** object, and _row_ and _column_ are relative to the upper-left corner of the range, to return part of a range. The following example sets the formula for cell C5.
+Use_expression_.**Cells**, where _expression_ is an expression that returns a **Range** object, to obtain a range with the same address consisting of single cells.
+On such a range, you access single cells via **Item**(_row_, _column_), where are relative to the upper-left corner of the first area of the range. 
+**Item** can be omitted since the call is forwarded to it by the default member of **Range**.
+The following example sets the formula for cell C5 and D5 of the first sheet of the active workbook.
 
 ```vb
 Worksheets(1).Range("C5:C10").Cells(1, 1).Formula = "=Rand()"
+Worksheets(1).Range("C5:C10").Cells.Item(1, 2).Formula = "=Rand()"
 ```
 
 <br/>
@@ -113,6 +124,72 @@ With Worksheets(1)
     .Range(.Cells(1, 1), _ 
         .Cells(10, 10)).Borders.LineStyle = xlThick 
 End With
+```
+
+<br/>
+
+Use **Rows** on a worksheet to obtain a range consisting all rows on the worksheet. You can access single rows via **Item**(_row_), where _row_ is the row index. 
+**Item** can be omitted since the call is forwarded to it by the default member of **Range**. 
+
+> [!NOTE] 
+> It is not legal to provide the second parameter of **Item** for ranges consisting of rows. You first have to convert it to single cells via **Cells**. 
+
+The following example deletes row 4 and 10 of the first sheet of the active workbook.
+
+```vb
+Worksheets(1).Rows(10).Delete
+Worksheets(1).Rows.Item(5).Delete
+```
+
+<br/>
+
+Use **Columns** on a worksheet to obtain a range consisting all columns on the worksheet. You can access single columns via **Item**(_row_) [sic], where _row_ is the column index given as a number or as an A1-style column address. 
+**Item** can be omitted since the call is forwarded to it by the default member of **Range**. 
+
+> [!NOTE] 
+> It is not legal to provide the second parameter of **Item** for ranges consisting of columns. You first have to convert it to single cells via **Cells**.
+
+The following example deletes row "B", "C", "E", and "J" of the first sheet of the active workbook.
+
+```vb
+Worksheets(1).Columns(10).Delete
+Worksheets(1).Columns.Item(5).Delete
+Worksheets(1).Columns("C").Delete
+Worksheets(1).Columns.Item("B").Delete
+```
+
+<br/>
+
+Use_expression_.**Rows**, where _expression_ is an expression that returns a **Range** object, to obtain a range consisting of the rows in the first area of the range.
+You can access single rows via **Item**(_row_), where _row_ is the relative row index from the top of the first area of the range. 
+**Item** can be omitted since the call is forwarded to it by the default member of **Range**.
+
+> [!NOTE] 
+> It is not legal to provide the second parameter of **Item** for ranges consisting of rows. You first have to convert it to single cells via **Cells**.
+
+The following example deletes the ranges C8:D8 and C6:D6 of the first sheet of the active workbook.
+
+```vb
+Worksheets(1).Range("C5:D10").Rows(4).Delete
+Worksheets(1).Range("C5:D10").Rows.Item(2).Delete
+```
+
+<br/>
+
+Use_expression_.**Columns**, where _expression_ is an expression that returns a **Range** object, to obtain a range consisting of the columns in the first area of the range.
+You can access single columns via **Item**(_row_) [sic], where _row_ is the relative column index from the left of the first area of the range given as a number or as an A1-style column address. 
+**Item** can be omitted since the call is forwarded to it by the default member of **Range**.
+
+> [!NOTE] 
+> It is not legal to provide the second parameter of **Item** for ranges consisting of columns. You first have to convert it to single cells via **Cells**.
+
+The following example deletes the ranges L2:L10, G2:G10, F2:F10 and D2:D10 of the first sheet of the active workbook.
+
+```vb
+Worksheets(1).Range("C5:Z10").Columns(10).Delete
+Worksheets(1).Range("C5:Z10").Columns.Item(5).Delete
+Worksheets(1).Range("C5:Z10").Columns("D").Delete
+Worksheets(1).Range("C5:Z10").Columns.Item("B").Delete
 ```
 
 <br/>

--- a/api/Excel.Range(object).md
+++ b/api/Excel.Range(object).md
@@ -20,7 +20,7 @@ Represents a cell, a row, a column, a selection of cells containing one or more 
 
 ## Remarks
 
-The default member of **Range** forwards calls without parameters to the **[Value](Excel.Range.Value)** property and calls with parameters to the **[Item](Excel.Range.Item)** member. Accordingly, `someRange = someOtherRange` is equivalent to `someRange.Value = someOtherRange.Value`, `someRange(1)` to `someRange.Item(1)` and `someRange(1,1)` to `someRange.Item(1,1)`.
+The default member of **Range** forwards calls without parameters to the **[Value](Excel.Range.Value.md)** property and calls with parameters to the **[Item](Excel.Range.Item.md)** member. Accordingly, `someRange = someOtherRange` is equivalent to `someRange.Value = someOtherRange.Value`, `someRange(1)` to `someRange.Item(1)` and `someRange(1,1)` to `someRange.Item(1,1)`.
 
 The following properties and methods for returning a **Range** object are described in the **Example** section:
 

--- a/api/Excel.Range(object).md
+++ b/api/Excel.Range(object).md
@@ -149,7 +149,7 @@ Use **Columns** on a worksheet to obtain a range consisting all columns on the w
 > [!NOTE] 
 > It is not legal to provide the second parameter of **Item** for ranges consisting of columns. You first have to convert it to single cells via **Cells**.
 
-The following example deletes row "B", "C", "E", and "J" of the first sheet of the active workbook.
+The following example deletes column "B", "C", "E", and "J" of the first sheet of the active workbook.
 
 ```vb
 Worksheets(1).Columns(10).Delete

--- a/api/Excel.Range.Cells.md
+++ b/api/Excel.Range.Cells.md
@@ -28,18 +28,20 @@ _expression_ A variable that represents a **[Range](excel.range(object).md)** ob
 
 ## Remarks
 
-Because the **[Item](Excel.Range.Item.md)** property is the default property for the **Range** object, you can specify the row and column index immediately after the **Cells** keyword. For more information, see the **Item** property and the examples for this topic.
+The return value is a **Range** consisting of single cells, which allows to use the version of the **[Item](Excel.Range.Item.md)** with two parameters and lets `For Each` loops iterate over single cells.
 
-Using this property without an object qualifier returns a **Range** object that represents all the cells on the active worksheet.
+Because the default member of **Range** forwards calls with parameters to the **[Item](Excel.Range.Item.md)** property, you can specify the row and column index immediately after the **Cells** keyword instead of an explicit call to **[Item](Excel.Range.Item.md)**.
 
+Using **Cells** without an object qualifier is equivalent to **[ActiveSheet.Cells](Excel.Worksheet.Cells.md)**.
 
 ## Example
 
-This example sets the font style for cells A1:C5 on Sheet1 to italic.
+This example sets the font style for cells B2:D6 on Sheet1 of the active workbook to italic.
 
 ```vb
-Worksheets("Sheet1").Activate 
-Range(Cells(1, 1), Cells(5, 3)).Font.Italic = True
+With Worksheets("Sheet1").Range("B2:Z100") 
+   .Range(.Cells(1, 1), .Cells(5, 3)).Font.Italic = True
+End With
 ```
 
 <br/>
@@ -52,29 +54,42 @@ For n = 2 To r.Rows.Count
     If r.Cells(n-1, 1) = r.Cells(n, 1) Then 
         MsgBox "Duplicate data in " & r.Cells(n, 1).Address 
     End If 
-Next n
+Next
 ```
 
 <br/>
 
-This example looks through column C, and for every cell that has a comment, it puts the comment text into column D and deletes the comment from column C.
+This example demonstrates how **Cells** changes the behavior of the **[Item](Excel.Range.Item.md)** member.  
 
 ```vb
-Sub SplitComments()
-   'Set up your variables
-   Dim cmt As Comment
-   Dim iRow As Integer
+Public Sub PrintRangeAdresses
+   Dim columnsRange As Excel.Range
+   Set columnsRange = ThisWorkBook.Worksheets("exampleSheet").Range("B2:Z100").Columns
    
-   'Go through all the cells in Column C, and check to see if the cell has a comment.
-   For iRow = 1 To WorksheetFunction.CountA(Columns(3))
-      Set cmt = Cells(iRow, 3).Comment
-      If Not cmt Is Nothing Then
-      
-         'If there is a comment, paste the comment text into column D and delete the original comment.
-         Cells(iRow, 4) = Cells(iRow, 3).Comment.Text
-         Cells(iRow, 3).Comment.Delete
-      End If
-   Next iRow
+   Debug.Print columnsRange.Item(2).Address         'Prints "$C$2:$C$100" 
+   Debug.Print columnsRange.Cells.Item(2).Address   'Prints "$C$2" 
+   Debug.Print columnsRange.Cells.Item(2,1).Address 'Prints "$B$3"   
+End Sub
+```
+
+<br/>
+
+This example demonstrates how **Cells** changes the enumeration behavior.
+
+```vb
+Public Sub PrintAllRangeAdresses
+   Dim columnsRange As Excel.Range
+   Set columnsRange = ThisWorkBook.Worksheets("exampleSheet").Range("B2:C3").Columns
+   
+   Dim columnRange As Excel.Range
+   For Each columnRange In columnsRange
+      Debug.Print columnRange.Address   'Prints "$B$2:$B$3", "$C$2:$C$3"
+   Next
+   
+   Dim cell As Excel.Range
+   For Each cell In columnsRange.Cells
+      Debug.Print cell.Address          'Prints "$B$2", "$C$2", "$B$3", "$C$3"
+   Next  
 End Sub
 ```
 

--- a/api/Excel.Range.Columns.md
+++ b/api/Excel.Range.Columns.md
@@ -26,9 +26,9 @@ _expression_ A variable that represents a **[Range](excel.range(object).md)** ob
 
 ## Remarks
 
-To return a single column, include an index in parentheses. For example, `Selection.Columns(1)` returns the first column of the selection.
+To return a single column, use the **[Item](Excel.Range.Item.md)** property or equivalently include an index in parentheses. For example, both `Selection.Columns(1)` and `Selection.Columns.Item(1)` return the first column of the selection.
 
-When applied to a **Range** object that's a multiple-area selection, this property returns columns from only the first area of the range. For example, if the **Range** object has two areas—A1:B2 and C3:D4—`Selection.Columns.Count` returns 2, not 4. To use this property on a range that may contain a multiple-area selection, test `Areas.Count` to determine whether the range contains more than one area. If it does, loop over each area in the range.
+When applied to a **Range** object that is a multiple-area selection, this property returns columns from only the first area of the range. For example, if the **Range** object has two areas—A1:B2 and C3:D4—`Selection.Columns.Count` returns 2, not 4. To use this property on a range that may contain a multiple-area selection, test `Areas.Count` to determine whether the range contains more than one area. If it does, loop over each area in the range.
 
 The returned range might be outside the specified range. For example, `Range("A1:B2").Columns(5).Select` returns cells E1:E2.
 
@@ -49,19 +49,29 @@ Range("myRange").Columns(1).Value = 0
 This example displays the number of columns in the selection on Sheet1. If more than one area is selected, the example loops through each area.
 
 ```vb
-Worksheets("Sheet1").Activate 
-areaCount = Selection.Areas.Count 
-If areaCount <= 1 Then 
- MsgBox "The selection contains " & _ 
- Selection.Columns.Count & " columns." 
-Else 
- For i = 1 To areaCount 
- MsgBox "Area " & i & " of the selection contains " & _ 
- Selection.Areas(i).Columns.Count & " columns." 
- Next i 
-End If
+Public Sub ShowNumberOfColumnsInSheet1Selection
+   Worksheets("Sheet1").Activate 
+   
+   Dim selectedRange As Excel.Range
+   Set selectedRange = Selection
+   
+   Dim areaCount As Long
+   areaCount = Selection.Areas.Count 
+   
+   If areaCount <= 1 Then 
+      MsgBox "The selection contains " & _ 
+             Selection.Columns.Count & " columns." 
+   Else 
+      Dim areaIndex As Long
+      areaIndex = 1 
+      For Each area In Selection.Areas 
+         MsgBox "Area " & areaIndex & " of the selection contains " & _ 
+                area.Columns.Count & " columns." 
+         areaIndex = areaIndex + 1 
+      Next 
+   End If
+End Sub
 ```
-
 
 
 

--- a/api/Excel.Range.Item.md
+++ b/api/Excel.Range.Item.md
@@ -56,7 +56,7 @@ The range returned when providing only one parameter depends on the nature of th
 
 The following example shows which cell is returned if both parameters are provided. 
 
-```vba 
+```vb
 Public Sub PrintAdresses()
    Dim exampleRange As Excel.Range
    With ThisWorkbook.Worksheets("ExampleSheet")
@@ -73,7 +73,7 @@ End Sub
 
 The following example shows for different types of ranges which subranges are returned if only one parameter is provided.
 
-```vba 
+```vb
 Public Sub PrintAdresses()
    Dim exampleRange As Excel.Range
    With ThisWorkbook.Worksheets("ExampleSheet")

--- a/api/Excel.Range.Item.md
+++ b/api/Excel.Range.Item.md
@@ -28,23 +28,53 @@ _expression_ A variable that represents a **[Range](excel.range(object).md)** ob
 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
-| _RowIndex_|Required| **Variant**|The index number of the cell that you want to access, in order from left to right, and then down.<br/><br/>`Range.Item(1)` returns the upper-left cell in the range.<br/><br/>`Range.Item(2)` returns the cell immediately to the right of the upper-left cell. |
-| _ColumnIndex_|Optional| **Variant**|A number or string that indicates the column number of the cell that you want to access, starting with either 1 or A for the first column in the range.|
+| _RowIndex_|Required| **Variant**|If the second argument is provided, the relative row number of the cell to return.<br/><br/>If the second argument is not provided, the index of the subrange to return. |
+| _ColumnIndex_|Optional| **Variant**|The relative column number of the cell to return.|
 
 ## Remarks
 
-Syntax 1 uses a row number and a column number or letter as index arguments. For more information about this syntax, see the **Range** object. 
+If _expression_ is not a range containing a collection of single cells, e.g. because is has been obtained via the `[Columns](Excel.Range.Columns.md)` member, providing the second argument is illegal and will result in an error 1004. 
+
+The default member of **Range** forwards calls with parameters to the **Item** member. Thus, `someRange(1)` and `someRange(1,1)` are equivalent to `someRange.Item(1)` and `someRange.Item(1,1)`, respectively.
 
 The _RowIndex_ and _ColumnIndex_ arguments are relative offsets. In other words, specifying a _RowIndex_ of 1 returns cells in the first row of the range, not the first row of the worksheet. For example, if the selection is cell C3, `Selection.Cells(2, 2)` returns cell D4 (you can use the **Item** property to index outside the original range).
+
+The enumeration order when supplying one parameter agrees with that used when enumerating the range in a `For Each` loop. For ranges consisting of single cells, as returned by the `[Cells](Excel.Range.Cells.md)` member, this is left-to-right than top-to-bottom, as for two-dimentional arrays. For ranges consisting of row ranges, as returned by `[Rows](Excel.Range.Rows.md)`, it is top-to-bottom and for ranges consisting of column ranges, as returned by `[Columns](Excel.Range.Columns.md)`, it is left-to-right.
+
+If _expression_ is a range consisting of column ranges, the parameter _RowIndex_ refers to the relative column index and not to the relative row index.
 
 
 ## Example
 
-This example fills the range A1:A10 on Sheet1, based on the contents of cell A1. The **[Cells](excel.range.cells.md)** property returns a **Range** object.
+The following example shows which cell is returned if both parameters are provided. 
 
-```vb
-Worksheets("Sheet1").Cells.Item("A1:A10").FillDown.
+```vba 
+Public Sub PrintAdresses()
+  Dim exampleRange As Excel.Range
+  Set exampleRange = ThisWorkbook.Worksheets("ExampleSheet").Range("B2:D4")
+  
+  Debug.Print exampleRange.Item(1,1).Address  'Prints "$B$2"
+  Debug.Print exampleRange.Item(2,4).Address  'Prints "$E$3"
+End Sub
+```
 
+The following example shows for different types of ranges which subranges are returned if only one parameter is provided.
+
+```vba 
+Public Sub PrintAdresses()
+  Dim exampleRange As Excel.Range
+  Set exampleRange = ThisWorkbook.Worksheets("ExampleSheet").Range("B2:D4")
+  
+  Debug.Print exampleRange.Cells.Item(1).Address  'Prints "$B$2"
+  Debug.Print exampleRange.Cells.Item(2).Address  'Prints "$C$2"
+  Debug.Print exampleRange.Cells.Item(4).Address  'Prints "$B$3"
+  
+  Debug.Print exampleRange.Rows.Item(1).Address  'Prints "$B$2:$D$2"
+  Debug.Print exampleRange.Rows.Item(2).Address  'Prints "$B$3:$D$3"
+  
+  Debug.Print exampleRange.Columns.Item(1).Address  'Prints "$B$2:$B$4"
+  Debug.Print exampleRange.Columns.Item(2).Address  'Prints "$C$1:$C$4"
+End Sub
 ```
 
 

--- a/api/Excel.Range.Item.md
+++ b/api/Excel.Range.Item.md
@@ -45,7 +45,7 @@ It is possible to reference cells outside the original range using the **Item** 
 
 The range returned when providing only one parameter depends on the nature of the range: 
 
-  - For ranges consisting of single cells, as returned by the **[Cells](Excel.Range.Cells.md)** and **[Range](Excel.Worsheet.Range.md)** members, **Item** returns single cells. The parameter _RowIndex_ refers to the index when enumerating the first area of the range left-to-right than top-to-bottom, as for two-dimentional arrays. If _RowIndex_ is larger than the number of cells in the first area of the range, the enumeration as if the area was extended downwards. 
+  - For ranges consisting of single cells, as returned by the **[Cells](Excel.Range.Cells.md)** and **[Range](Excel.Worksheet.Range.md)** members, **Item** returns single cells. The parameter _RowIndex_ refers to the index when enumerating the first area of the range left-to-right than top-to-bottom, as for two-dimentional arrays. If _RowIndex_ is larger than the number of cells in the first area of the range, the enumeration as if the area was extended downwards. 
 
   - For ranges consisting of row ranges, as returned by **[Rows](Excel.Range.Rows.md)**, **Item** returns row ranges. The parameter _RowIndex_ is the 1-based offset from the first row of the range in the direction top-to-bottom. 
   

--- a/api/Excel.Range.Item.md
+++ b/api/Excel.Range.Item.md
@@ -33,15 +33,23 @@ _expression_ A variable that represents a **[Range](excel.range(object).md)** ob
 
 ## Remarks
 
-If _expression_ is not a range containing a collection of single cells, e.g. because is has been obtained via the `[Columns](Excel.Range.Columns.md)` member, providing the second argument is illegal and will result in an error 1004. 
+If _expression_ is not a range containing a collection of single cells, e.g. because is has been obtained via the **[Columns](Excel.Range.Columns.md)** member, providing the second argument is illegal and will result in an error 1004. 
 
 The default member of **Range** forwards calls with parameters to the **Item** member. Thus, `someRange(1)` and `someRange(1,1)` are equivalent to `someRange.Item(1)` and `someRange.Item(1,1)`, respectively.
 
-The _RowIndex_ and _ColumnIndex_ arguments are relative offsets. In other words, specifying a _RowIndex_ of 1 returns cells in the first row of the range, not the first row of the worksheet. For example, if the selection is cell C3, `Selection.Cells(2, 2)` returns cell D4 (you can use the **Item** property to index outside the original range).
+The _RowIndex_ and _ColumnIndex_ arguments are relative 1-based offsets to the top-left cell of the first area of the range as returned by the **[Areas](Excel.Range.Areas.md)** member, i.e. for the range `Union(someSheet.Range("Z4:AA6"), someSheet.Range("A1:C3"))`, `Item(1,1)` will return the range with address $Z$4.
 
-The enumeration order when supplying one parameter agrees with that used when enumerating the range in a `For Each` loop. For ranges consisting of single cells, as returned by the `[Cells](Excel.Range.Cells.md)` member, this is left-to-right than top-to-bottom, as for two-dimentional arrays. For ranges consisting of row ranges, as returned by `[Rows](Excel.Range.Rows.md)`, it is top-to-bottom and for ranges consisting of column ranges, as returned by `[Columns](Excel.Range.Columns.md)`, it is left-to-right.
+The _ColumnIndex_ can be provided either as a numeric index or as a column address string as in A1-notation, i.e. `"A"` refers to the numeric index `1` and `"AA"` to `27`. 
 
-If _expression_ is a range consisting of column ranges, the parameter _RowIndex_ refers to the relative column index and not to the relative row index.
+It is possible to reference cells outside the original range using the **Item** property by providing appropriate arguments, e.g. `Item(3,3)` will return the cell at `"D4"` for the range `someSheet.Range("B2:C3")`. 
+
+The range returned when providing only one parameter depends on the nature of the range: 
+
+  - For ranges consisting of single cells, as returned by the **[Cells](Excel.Range.Cells.md)** and **[Range](Excel.Worsheet.Range.md)** members, **Item** returns single cells. The parameter _RowIndex_ refers to the index when enumerating the first area of the range left-to-right than top-to-bottom, as for two-dimentional arrays. If _RowIndex_ is larger than the number of cells in the first area of the range, the enumeration as if the area was extended downwards. 
+
+  - For ranges consisting of row ranges, as returned by **[Rows](Excel.Range.Rows.md)**, **Item** returns row ranges. The parameter _RowIndex_ is the 1-based offset from the first row of the range in the direction top-to-bottom. 
+  
+  - For ranges consisting of column ranges, as returned by **[Columns](Excel.Range.Columns.md)**, **Item** returns column ranges. The parameter _RowIndex_ is the 1-based offset from the first column in the direction left-to-right. In this situation, the index may alternatively be provided as a column address string.
 
 
 ## Example
@@ -50,11 +58,16 @@ The following example shows which cell is returned if both parameters are provid
 
 ```vba 
 Public Sub PrintAdresses()
-  Dim exampleRange As Excel.Range
-  Set exampleRange = ThisWorkbook.Worksheets("ExampleSheet").Range("B2:D4")
+   Dim exampleRange As Excel.Range
+   With ThisWorkbook.Worksheets("ExampleSheet")
+      Set exampleRange = Application.Union(.Range("B2:D4"), .Range("A1"), .Range("Z1:AA20"))
+   End With
   
-  Debug.Print exampleRange.Item(1,1).Address  'Prints "$B$2"
-  Debug.Print exampleRange.Item(2,4).Address  'Prints "$E$3"
+   Debug.Print exampleRange.Item(1,1).Address      'Prints "$B$2"
+   Debug.Print exampleRange.Item(2,4).Address      'Prints "$E$3"
+   Debug.Print exampleRange.Item(20,40).Address    'Prints "$AO$21"
+   Debug.Print exampleRange.Item(2,"D").Address    'Prints "$E$3"
+   Debug.Print exampleRange.Item(20,"AN").Address  'Prints "$E$3"
 End Sub
 ```
 
@@ -62,18 +75,23 @@ The following example shows for different types of ranges which subranges are re
 
 ```vba 
 Public Sub PrintAdresses()
-  Dim exampleRange As Excel.Range
-  Set exampleRange = ThisWorkbook.Worksheets("ExampleSheet").Range("B2:D4")
+   Dim exampleRange As Excel.Range
+   With ThisWorkbook.Worksheets("ExampleSheet")
+      Set exampleRange = Application.Union(.Range("B2:D4"), .Range("A1"), .Range("Z1:AA20"))
+   End With
+
+   Debug.Print exampleRange.Cells.Item(1).Address      'Prints "$B$2"
+   Debug.Print exampleRange.Cells.Item(2).Address      'Prints "$C$2"
+   Debug.Print exampleRange.Cells.Item(4).Address      'Prints "$B$3"
+   Debug.Print exampleRange.Cells.Item(10).Address     'Prints "$B$5"
   
-  Debug.Print exampleRange.Cells.Item(1).Address  'Prints "$B$2"
-  Debug.Print exampleRange.Cells.Item(2).Address  'Prints "$C$2"
-  Debug.Print exampleRange.Cells.Item(4).Address  'Prints "$B$3"
+   Debug.Print exampleRange.Rows.Item(1).Address       'Prints "$B$2:$D$2"
+   Debug.Print exampleRange.Rows.Item(10).Address      'Prints "$B$11:$D$11"
   
-  Debug.Print exampleRange.Rows.Item(1).Address  'Prints "$B$2:$D$2"
-  Debug.Print exampleRange.Rows.Item(2).Address  'Prints "$B$3:$D$3"
-  
-  Debug.Print exampleRange.Columns.Item(1).Address  'Prints "$B$2:$B$4"
-  Debug.Print exampleRange.Columns.Item(2).Address  'Prints "$C$1:$C$4"
+   Debug.Print exampleRange.Columns.Item(1).Address    'Prints "$B$2:$B$4"
+   Debug.Print exampleRange.Columns.Item(10).Address   'Prints "$K$1:$K$4"
+   Debug.Print exampleRange.Columns.Item("A").Address  'Prints "$B$1:$B$4"
+   Debug.Print exampleRange.Columns.Item("J").Address  'Prints "$K$1:$K$4"
 End Sub
 ```
 

--- a/api/Excel.Range.Range.md
+++ b/api/Excel.Range.Range.md
@@ -33,61 +33,47 @@ _expression_ A variable that represents a **[Range](Excel.Range(object).md)** ob
 
 ## Remarks
 
-When used without an object qualifier, this property is a shortcut for **ActiveSheet.Range** (it returns a range from the active sheet; if the active sheet isn't a worksheet, the property fails).
+When used without an object qualifier, this property is a shortcut for **[ActiveSheet.Range](Excel.Worksheet.Range.md)** (it returns a range from the active sheet; if the active sheet isn't a worksheet, the property fails).
 
 When applied to a **Range** object, the property is relative to the **Range** object. For example, if the selection is cell C3, `Selection.Range("B1")` returns cell D3 because it's relative to the **Range** object returned by the **Selection** property. On the other hand, the code `ActiveSheet.Range("B1")` always returns cell B1.
 
 
 ## Example
 
-This example sets the value of cell A1 on Sheet1 to 3.14159.
+This example sets the value of the top-left cell of the range B2:C4 on Sheet1 of the active workbook, i.e. that of the cell B2, to 3.14159.
 
-```vb
-Worksheets("Sheet1").Range("A1").Value = 3.14159
+```vba
+With Worksheets("Sheet1").Range("B2:C4")
+   .Range("A1").Value = 3.14159
+End With
 ```
 
 <br/>
 
-This example creates a formula in cell A1 on Sheet1.
+This example loops on the the four cells in the top-left corner of the range B2:Z22 on Sheet1 of the active workbook. If one of the cells has a value less than 0.001, the code replaces that value with 0 (zero).
 
-```vb
-Worksheets("Sheet1").Range("A1").Formula = "=10*RAND()"
+```vba
+Public Sub TruncateSmallValues()
+   Dim exampleRange As Excel.Range
+   Set exampleRange = Worksheets("Sheet1").Range("B2:Z22") 
+
+   Dim cell As Excel.Range
+   For Each cell in exampleRange.Range("A1:B2") 
+      If cell.Value < .001 Then 
+         cell.Value = 0 
+      End If 
+   Next cell
+End Sub
 ```
 
 <br/>
 
-This example loops on cells A1:D10 on Sheet1. If one of the cells has a value less than 0.001, the code replaces that value with 0 (zero).
+This example sets the font style in cells B2:D6 on Sheet1 of the active workbook to italic. The example uses Syntax 2 of the **Range** property.
 
-```vb
-For Each c in Worksheets("Sheet1").Range("A1:D10") 
- If c.Value < .001 Then 
- c.Value = 0 
- End If 
-Next c
-```
-
-<br/>
-
-This example loops on the range named TestRange and displays the number of empty cells in the range.
-
-```vb
-numBlanks = 0 
-For Each c In Range("TestRange") 
- If c.Value = "" Then 
- numBlanks = numBlanks + 1 
- End If 
-Next c 
-MsgBox "There are " & numBlanks & " empty cells in this range"
-```
-
-<br/>
-
-This example sets the font style in cells A1:C5 on Sheet1 to italic. The example uses Syntax 2 of the **Range** property.
-
-```vb
-Worksheets("Sheet1").Range(Cells(1, 1), Cells(5, 3)). _ 
- Font.Italic = True 
-
+```vba
+With Worksheets("Sheet1").Range("B2:Z22")
+   .Range(.Cells(1, 1), .Cells(5, 3)).Font.Italic = True 
+End With
 ```
 
 

--- a/api/Excel.Range.Range.md
+++ b/api/Excel.Range.Range.md
@@ -42,7 +42,7 @@ When applied to a **Range** object, the property is relative to the **Range** ob
 
 This example sets the value of the top-left cell of the range B2:C4 on Sheet1 of the active workbook, i.e. that of the cell B2, to 3.14159.
 
-```vba
+```vb
 With Worksheets("Sheet1").Range("B2:C4")
    .Range("A1").Value = 3.14159
 End With
@@ -52,7 +52,7 @@ End With
 
 This example loops on the the four cells in the top-left corner of the range B2:Z22 on Sheet1 of the active workbook. If one of the cells has a value less than 0.001, the code replaces that value with 0 (zero).
 
-```vba
+```vb
 Public Sub TruncateSmallValues()
    Dim exampleRange As Excel.Range
    Set exampleRange = Worksheets("Sheet1").Range("B2:Z22") 
@@ -70,7 +70,7 @@ End Sub
 
 This example sets the font style in cells B2:D6 on Sheet1 of the active workbook to italic. The example uses Syntax 2 of the **Range** property.
 
-```vba
+```vb
 With Worksheets("Sheet1").Range("B2:Z22")
    .Range(.Cells(1, 1), .Cells(5, 3)).Font.Italic = True 
 End With

--- a/api/Excel.Range.Rows.md
+++ b/api/Excel.Range.Rows.md
@@ -37,9 +37,9 @@ Using the **Rows** property without an object qualifier is equivalent to using *
 
 ## Example
 
-This example deletes the range "B5:Z5" on Sheet1 of the active workbook.
+This example deletes the range B5:Z5 on Sheet1 of the active workbook.
 
-```vba
+```vb
 Worksheets("Sheet1").Range("B2:Z44").Rows(3).Delete
 ```
 
@@ -47,7 +47,7 @@ Worksheets("Sheet1").Range("B2:Z44").Rows(3).Delete
 
 This example deletes rows in the current region on worksheet one of the active workbook where the value of cell one in the row is the same as the value of cell one in the previous row.
 
-```vba
+```vb
 For Each rw In Worksheets(1).Cells(1, 1).CurrentRegion.Rows
    this = rw.Cells(1, 1).Value 
    If this = last Then rw.Delete 
@@ -59,7 +59,7 @@ Next
 
 This example displays the number of rows in the selection on Sheet1. If more than one area is selected, the example loops through each area.
 
-```vba
+```vb
 Public Sub ShowNumberOfRowsInSheet1Selection
    Worksheets("Sheet1").Activate 
    

--- a/api/Excel.Range.Rows.md
+++ b/api/Excel.Range.Rows.md
@@ -26,32 +26,32 @@ _expression_ A variable that represents a **[Range](excel.range(object).md)** ob
 
 ## Remarks
 
-To return a single row, include an index in parentheses. For example, `Selection.Rows(1)` returns the first row of the selection. 
+To return a single row, use the **[Item](Excel.Range.Item.md)** property or equivalently include an index in parentheses. For example, both `Selection.Rows(1)` and `Selection.Rows.Item(1)` return the first row of the selection.
 
-When applied to a **Range** object that's a multiple selection, this property returns rows from only the first area of the range. For example, if the **Range** object has two areas—A1:B2 and C3:D4—,`Selection.Rows.Count` returns 2, not 4. To use this property on a range that may contain a multiple selection, test **Areas.Count** to determine whether the range is a multiple selection. If it is, loop over each area in the range, as shown in the third example.
+When applied to a **Range** object that is a multiple selection, this property returns rows from only the first area of the range. For example, if the **Range** object `someRange` has two areas—A1:B2 and C3:D4—,`someRange.Rows.Count` returns 2, not 4. To use this property on a range that may contain a multiple selection, test **Areas.Count** to determine whether the range is a multiple selection. If it is, loop over each area in the range, as shown in the third example.
 
-The returned range might be outside the specified range. For example, `Range("A1:B2").Rows(5).Select` returns cells A5:B5.
+The returned range might be outside the specified range. For example, `Range("A1:B2").Rows(5)` returns cells A5:B5. For more information, see the **[Item](Excel.Range.Item.md)** property.
 
 Using the **Rows** property without an object qualifier is equivalent to using **ActiveSheet.Rows**. For more information, see the **[Worksheet.Rows](excel.worksheet.rows.md)** property.
 
 
 ## Example
 
-This example deletes row three on Sheet1.
+This example deletes the range "B5:Z5" on Sheet1 of the active workbook.
 
-```vb
-Worksheets("Sheet1").Rows(3).Delete
+```vba
+Worksheets("Sheet1").Range("B2:Z44").Rows(3).Delete
 ```
 
 <br/>
 
-This example deletes rows in the current region on worksheet one where the value of cell one in the row is the same as the value of cell one in the previous row.
+This example deletes rows in the current region on worksheet one of the active workbook where the value of cell one in the row is the same as the value of cell one in the previous row.
 
-```vb
-For Each rw In Worksheets(1).Cells(1, 1).CurrentRegion.Rows 
- this = rw.Cells(1, 1).Value 
- If this = last Then rw.Delete 
- last = this 
+```vba
+For Each rw In Worksheets(1).Cells(1, 1).CurrentRegion.Rows
+   this = rw.Cells(1, 1).Value 
+   If this = last Then rw.Delete 
+   last = this 
 Next
 ```
 
@@ -59,20 +59,29 @@ Next
 
 This example displays the number of rows in the selection on Sheet1. If more than one area is selected, the example loops through each area.
 
-```vb
-Worksheets("Sheet1").Activate 
-areaCount = Selection.Areas.Count 
-If areaCount <= 1 Then 
- MsgBox "The selection contains " & _ 
- Selection.Rows.Count & " rows." 
-Else 
- i = 1 
- For Each a In Selection.Areas 
- MsgBox "Area " & i & " of the selection contains " & _ 
- a.Rows.Count & " rows." 
- i = i + 1 
- Next a 
-End If
+```vba
+Public Sub ShowNumberOfRowsInSheet1Selection
+   Worksheets("Sheet1").Activate 
+   
+   Dim selectedRange As Excel.Range
+   Set selectedRange = Selection
+   
+   Dim areaCount As Long
+   areaCount = Selection.Areas.Count 
+   
+   If areaCount <= 1 Then 
+      MsgBox "The selection contains " & _ 
+             Selection.Rows.Count & " rows." 
+   Else 
+      Dim areaIndex As Long
+      areaIndex = 1 
+      For Each area In Selection.Areas 
+         MsgBox "Area " & areaIndex & " of the selection contains " & _ 
+                area.Rows.Count & " rows." 
+         areaIndex = areaIndex + 1 
+      Next 
+   End If
+End Sub
 ```
 
 

--- a/api/Excel.Range.Value.md
+++ b/api/Excel.Range.Value.md
@@ -47,7 +47,7 @@ Assigning an array to a multi-area range is not properly supported and should be
 
 This example sets the value of cell A1 on Sheet1 of the active workbook to 3.14159.
 
-```vba
+```vb
 Worksheets("Sheet1").Range("A1").Value = 3.14159
 ```
 
@@ -55,7 +55,7 @@ Worksheets("Sheet1").Range("A1").Value = 3.14159
 
 This example loops on cells A1:D10 on Sheet1 of the active workbook. If one of the cells has a value of less than 0.001, the code replaces the value with 0 (zero).
 
-```vba
+```vb
 For Each cell in Worksheets("Sheet1").Range("A1:D10") 
    If cell.Value < .001 Then 
       cell.Value = 0 
@@ -67,7 +67,7 @@ Next cell
 
 This example loops over the values in the range A1:CC5000 on Sheet1. If one of the values is less than 0.001, the code replaces the value with 0 (zero). Finally it copies the values to the original range.
 
-```vba
+```vb
 Public Sub TruncateSmallValuesInDataArea()
    Dim dataArea As Excel.Range
    Set dataArea = ThisworkBook.Worksheets("Sheet1").Range("A1:CC5000")

--- a/api/Excel.Range.Value.md
+++ b/api/Excel.Range.Value.md
@@ -60,7 +60,7 @@ For Each cell in Worksheets("Sheet1").Range("A1:D10")
    If cell.Value < .001 Then 
       cell.Value = 0 
    End If 
-Next c
+Next cell
 ```
 
 <br/>

--- a/api/Excel.Range.Value.md
+++ b/api/Excel.Range.Value.md
@@ -34,25 +34,59 @@ _expression_ A variable that represents a **[Range](excel.range(object).md)** ob
 
 When setting a range of cells with the contents of an XML spreadsheet file, only values of the first sheet in the workbook are used. You cannot set or get a discontiguous range of cells in the XML spreadsheet format.
 
+The default member of **Range** forwards calls without parameters to **Value**. Thus, `someRange = someOtherRange` is equivalent to `someRange.Value = someOtherRange.Value`.
+
+For ranges whose first area contains more than one cell, **Value** returns a **Variant** containing a 2-dimensional array of the values in the individual cells of the first range.
+
+Assigning a 2-dim array to the the **Value** property will copy the values to the range in one operation. If the target range is larger than the array, the remaining cells will receive an error value.
+
+Assigning an array to a multi-area range is not properly supported and should be avoided.
+
 
 ## Example
 
-This example sets the value of cell A1 on Sheet1 to 3.14159.
+This example sets the value of cell A1 on Sheet1 of the active workbook to 3.14159.
 
-```vb
+```vba
 Worksheets("Sheet1").Range("A1").Value = 3.14159
 ```
 
 <br/>
 
-This example loops on cells A1:D10 on Sheet1. If one of the cells has a value of less than 0.001, the code replaces the value with 0 (zero).
+This example loops on cells A1:D10 on Sheet1 of the active workbook. If one of the cells has a value of less than 0.001, the code replaces the value with 0 (zero).
 
-```vb
-For Each c in Worksheets("Sheet1").Range("A1:D10") 
- If c.Value < .001 Then 
- c.Value = 0 
- End If 
+```vba
+For Each cell in Worksheets("Sheet1").Range("A1:D10") 
+   If cell.Value < .001 Then 
+      cell.Value = 0 
+   End If 
 Next c
+```
+
+<br/>
+
+This example loops over the values in the range A1:CC5000 on Sheet1. If one of the values is less than 0.001, the code replaces the value with 0 (zero). Finally it copies the values to the original range.
+
+```vba
+Public Sub TruncateSmallValuesInDataArea()
+   Dim dataArea As Excel.Range
+   Set dataArea = ThisworkBook.Worksheets("Sheet1").Range("A1:CC5000")
+   
+   Dim valuesArray() As Variant
+   valuesArray = dataArea.Value
+   
+   Dim rowIndex As Long
+   Dim columnIndex As Long
+   For rowIndex = LBound(valuesArray, 1) To UBound(valuesArray, 1)
+      For columnIndex = LBound(valuesArray, 2) To UBound(valuesArray, 2)
+	     If valuesArray(rowIndex, columnIndex) < 0.001 Then
+		    valuesArray(rowIndex, columnIndex) = 0
+		 End If 
+	  Next
+   Next
+   
+   dataArea.Value = valuesArray
+End Sub
 ```
 
 

--- a/api/Excel.Worksheet.Cells.md
+++ b/api/Excel.Worksheet.Cells.md
@@ -99,7 +99,7 @@ End Sub
 This example looks through column C of the active sheet, and for every cell that has a comment, it puts the comment text into column D and deletes the comment from column C.
 
 ```vb
-Sub SplitCommentsOnActiveSheet()
+Public Sub SplitCommentsOnActiveSheet()
    'Set up your variables
    Dim cmt As Comment
    Dim rowIndex As Integer
@@ -114,7 +114,8 @@ Sub SplitCommentsOnActiveSheet()
          Cells(rowIndex, 3).Comment.Delete
       End If
    Next
-End
+End Sub
+```
 
 
 

--- a/api/Excel.Worksheet.Cells.md
+++ b/api/Excel.Worksheet.Cells.md
@@ -26,14 +26,14 @@ _expression_ A variable that represents a **[Worksheet](Excel.Worksheet.md)** ob
 
 ## Remarks
 
-Because the **[Item](Excel.Range.Item.md)** property is the default property for the **Range** object, you can specify the row and column index immediately after the **Cells** keyword. For more information, see the **Item** property and the examples for this topic.
+Because the default member of **Range** forwards calls with parameters to the **[Item](Excel.Range.Item.md)** property, you can specify the row and column index immediately after the **Cells** keyword instead of an explicit call to **[Item](Excel.Range.Item.md)**.
 
 Using this property without an object qualifier returns a **Range** object that represents all the cells on the active worksheet.
 
 
 ## Example
 
-This example sets the font size for cell C5 on Sheet1 to 14 points.
+This example sets the font size for cell C5 on Sheet1 of the active workbook to 14 points.
 
 ```vb
 Worksheets("Sheet1").Cells(5, 3).Font.Size = 14
@@ -41,7 +41,7 @@ Worksheets("Sheet1").Cells(5, 3).Font.Size = 14
 
 <br/>
 
-This example clears the formula in cell one on Sheet1.
+This example clears the formula in cell one on Sheet1 of the active workbook.
 
 ```vb
 Worksheets("Sheet1").Cells(1).ClearContents
@@ -93,6 +93,28 @@ Private Sub Worksheet_BeforeDoubleClick(ByVal Target As Range, Cancel As Boolean
     End If
 End Sub
 ```
+
+<br/>
+
+This example looks through column C of the active sheet, and for every cell that has a comment, it puts the comment text into column D and deletes the comment from column C.
+
+```vb
+Sub SplitCommentsOnActiveSheet()
+   'Set up your variables
+   Dim cmt As Comment
+   Dim rowIndex As Integer
+   
+   'Go through all the cells in Column C, and check to see if the cell has a comment.
+   For rowIndex = 1 To WorksheetFunction.CountA(Columns(3))
+      Set cmt = Cells(rowIndex, 3).Comment
+      If Not cmt Is Nothing Then
+      
+         'If there is a comment, paste the comment text into column D and delete the original comment.
+         Cells(rowIndex, 4) = Cells(rowIndex, 3).Comment.Text
+         Cells(rowIndex, 3).Comment.Delete
+      End If
+   Next
+End
 
 
 

--- a/api/Excel.Worksheet.Columns.md
+++ b/api/Excel.Worksheet.Columns.md
@@ -28,7 +28,7 @@ _expression_ A variable that represents a **[Worksheet](Excel.Worksheet.md)** ob
 
 Using the **Columns** property without an object qualifier is equivalent to using **ActiveSheet.Columns**. If the active document isn't a worksheet, the **Columns** property fails.
 
-To return a single column, include an index in parentheses. For example, `Columns(1)` and `Columns("A")` return the first column.
+To return a single column, use the **[Item](Excel.Range.Item.md)** property or equivalently include an index in parentheses. For example, `Columns(1)`, `Columns("A")`, `Columns.Item(1)` and `Columns.Item("A")` return the first column a the active sheet.
 
 ## Example
 

--- a/api/Excel.Worksheet.Columns.md
+++ b/api/Excel.Worksheet.Columns.md
@@ -28,7 +28,7 @@ _expression_ A variable that represents a **[Worksheet](Excel.Worksheet.md)** ob
 
 Using the **Columns** property without an object qualifier is equivalent to using **ActiveSheet.Columns**. If the active document isn't a worksheet, the **Columns** property fails.
 
-To return a single column, use the **[Item](Excel.Range.Item.md)** property or equivalently include an index in parentheses. For example, `Columns(1)`, `Columns("A")`, `Columns.Item(1)` and `Columns.Item("A")` return the first column a the active sheet.
+To return a single column, use the **[Item](Excel.Range.Item.md)** property or equivalently include an index in parentheses. For example, `Columns(1)`, `Columns("A")`, `Columns.Item(1)` and `Columns.Item("A")` return the first column of the active sheet.
 
 ## Example
 

--- a/api/Excel.Worksheet.Range.md
+++ b/api/Excel.Worksheet.Range.md
@@ -62,7 +62,7 @@ Worksheets("Sheet1").Range("A1").Formula = "=10*RAND()"
 
 <br/>
 
-This example loops on cells A1:D10 on Sheet1. If one of the cells has a value less than 0.001, the code replaces that value with 0 (zero).
+This example loops on cells A1:D10 on Sheet1 of the active workbook. If one of the cells has a value less than 0.001, the code replaces that value with 0 (zero).
 
 ```vb
 For Each c in Worksheets("Sheet1").Range("A1:D10") 
@@ -88,12 +88,12 @@ MsgBox "There are " & numBlanks & " empty cells in this range"
 
 <br/>
 
-This example sets the font style in cells A1:C5 on Sheet1 to italic. The example uses Syntax 2 of the **Range** property.
+This example sets the font style in cells A1:C5 on Sheet1 of the active workbook to italic. The example uses Syntax 2 of the **Range** property.
 
 ```vb
-Worksheets("Sheet1").Range(Cells(1, 1), Cells(5, 3)). _ 
- Font.Italic = True 
-
+With Worksheets("Sheet1")
+	.Range(.Cells(1, 1), .Cells(5, 3)).Font.Italic = True
+End With
 ```
 
 <br/>

--- a/api/Excel.Worksheet.Rows.md
+++ b/api/Excel.Worksheet.Rows.md
@@ -28,7 +28,7 @@ _expression_ A variable that represents a **[Worksheet](Excel.Worksheet.md)** ob
 
 Using the **Rows** property without an object qualifier is equivalent to using **ActiveSheet.Rows**. If the active document isn't a worksheet, the **Rows** property fails.
 
-To return a single row, include an index in parentheses. For example, `Rows(1)` returns the first row.
+To return a single row, use the **[Item](Excel.Range.Item.md)** property or equivalently include an index in parentheses. For example, both `Rows(1)` and `Rows.Item(1)` return the first row of the active sheet.
 
 ## Example
 
@@ -40,34 +40,14 @@ Worksheets("Sheet1").Rows(3).Delete
 
 <br/>
 
-This example deletes rows in the current region on worksheet one where the value of cell one in the row is the same as the value of cell one in the previous row.
+This example deletes all rows on worksheet one where the value of cell one in the row is the same as the value of cell one in the previous row.
 
 ```vb
-For Each rw In Worksheets(1).Cells(1, 1).CurrentRegion.Rows 
- this = rw.Cells(1, 1).Value 
- If this = last Then rw.Delete 
- last = this 
+For Each rw In Worksheets(1).Rows 
+   this = rw.Cells(1, 1).Value 
+   If this = last Then rw.Delete 
+   last = this 
 Next
-```
-
-<br/>
-
-This example displays the number of rows in the selection on Sheet1. If more than one area is selected, the example loops through each area.
-
-```vb
-Worksheets("Sheet1").Activate 
-areaCount = Selection.Areas.Count 
-If areaCount <= 1 Then 
- MsgBox "The selection contains " & _ 
- Selection.Rows.Count & " rows." 
-Else 
- i = 1 
- For Each a In Selection.Areas 
- MsgBox "Area " & i & " of the selection contains " & _ 
- a.Rows.Count & " rows." 
- i = i + 1 
- Next a 
-End If
 ```
 
 


### PR DESCRIPTION
This PR clarifies the behaviour of `Range.Item` for different types of ranges (cells vs. rows vs. columns) and its connection to cell access.

This touches the `Cells`, `Columns` and `Rows` members both of `Range` and `Worksheet` as well as the page for `Range` itself. Apart amanding the corresponding pages for the connaction to `Item`, I amended or removed examples that did not use the member the page belonged to. (There were examples for the members of `Worksheet` on the pages for the properties of `Range` and the other way around.) 

If you desire any changes to this PR or have any questions, feel free to let me know. I am open to any criticism.