### PR TITLE
Update atendofstream-property.md

### DIFF
--- a/Language/Reference/User-Interface-Help/atendofstream-property.md
+++ b/Language/Reference/User-Interface-Help/atendofstream-property.md
@@ -32,7 +32,7 @@ The following code illustrates the use of the **AtEndOfStream** property.
 Dim fs, a, retstring
 Set fs = CreateObject("Scripting.FileSystemObject")
 Set a = fs.OpenTextFile("c:\testfile.txt", ForReading, False)
-Do While a. AtEndOfStream <> True
+Do While a.AtEndOfStream <> True
     retstring = a.ReadLine
     ...
 Loop


### PR DESCRIPTION
removed the errant space in the vba code between the variable "a" and the "AtEndofStream" property