### PR TITLE
Update atendofline-property.md

### DIFF
--- a/Language/Reference/User-Interface-Help/atendofline-property.md
+++ b/Language/Reference/User-Interface-Help/atendofline-property.md
@@ -32,7 +32,7 @@ The following code illustrates the use of the **AtEndOfLine** property.
 Dim fs, a, retstring
 Set fs = CreateObject("Scripting.FileSystemObject")
 Set a = fs.OpenTextFile("c:\testfile.txt", ForReading, False)
-Do While a. AtEndOfLine <> True
+Do While a.AtEndOfLine <> True
     retstring = a.Read(1)
     ...
 Loop


### PR DESCRIPTION
removed the errant space in the vba code between the variable "a" and the "AtEndofLine" property