### PR TITLE
Adding PpSaveAsFileType enum member

### DIFF
--- a/api/PowerPoint.PpSaveAsFileType.md
+++ b/api/PowerPoint.PpSaveAsFileType.md
@@ -17,6 +17,7 @@ Constants that specify type of file to save as, passed to the  **SaveAs** method
 |||
 |:-----|:-----|
 |**ppSaveAsAddIn**|8|
+|**ppSaveAsAnimatedGIF**|40|
 |**ppSaveAsBMP**|19|
 |**ppSaveAsDefault**|11|
 |**ppSaveAsEMF**|23|


### PR DESCRIPTION
ppSaveAsAnimatedGIF is a new supported type to save a deck out to. Updating the OM documentation using the same enum value given in ppt\ppt\desktop\objectmodel\shared\powerpnt.odl.