### PR TITLE
Update Excel.Worksheet.Activate(even).md

### DIFF
--- a/api/Excel.Worksheet.Activate(even).md
+++ b/api/Excel.Worksheet.Activate(even).md
@@ -42,7 +42,7 @@ This example sorts the range A1:A10 when the worksheet is activated.
 
 ```vb
 Private Sub Worksheet_Activate() 
- Range("a1:a10").Sort Key1:=Range("a1"), Order:=xlAscending 
+ Me.Range("a1:a10").Sort Key1:=Range("a1"), Order1:=xlAscending 
 End Sub
 ```
 


### PR DESCRIPTION
Fix typo: As per the [Range.Sort method](https://docs.microsoft.com/en-us/office/vba/api/excel.range.sort) up to 3 Key Order pairs can be accepted. Corrected named argument.

It's a moot point because it implicitly is doing the same thing, regardless I added `Me` to qualify the Range object and explicitly state which sheet the Range is on.