### PR TITLE
Remove git conflict markers from docs

### DIFF
--- a/outlook/Concepts/Getting-Started/customizing-outlook-using-com-add-ins.md
+++ b/outlook/Concepts/Getting-Started/customizing-outlook-using-com-add-ins.md
@@ -13,13 +13,7 @@ localization_priority: Normal
 
 Creating a COM add-in involves two major steps:
 
-<<<<<<< HEAD
 1. Implement the **IDTExtensibility2** interface in a class module of a dynamic link library (DLL).
-
-=======
-1. Implement the **IDTExtensibility2** interface in a class module of a dynamic link library (DLL).
-    
->>>>>>> 4e773a8f17332b1fec1a32d69a283faf1464bae6
 2. Register the COM add-in.
 
 ## Implement the IDTExtensibility2 Interface


### PR DESCRIPTION
Looks like git conflict markers made it into the documentation. Removed them.

ref: https://git-scm.com/docs/git-merge#_true_merge