### PR TITLE
Delete heading to make consistent with other enums

### DIFF
--- a/api/Word.wdrevisionsmarkup.md
+++ b/api/Word.wdrevisionsmarkup.md
@@ -9,10 +9,7 @@ localization_priority: Normal
 
 # WdRevisionsMarkup enumeration (Word)
 
-Constants that represent the extent of markup visible in the document, returned by and passed to the [RevisionsFilter.Markup](Word.revisionsfilter.markup.md) property.
-
-
-## Members
+Specifies the extent of markup visible in the document, returned by and passed to the [RevisionsFilter.Markup](Word.revisionsfilter.markup.md) property.
 
 
 


### PR DESCRIPTION
@lindalu-MSFT, I haven't looked at the VBA documentation in a while. Can you tell me what happens to proposed changes now? 

I see the note, "We are no longer accepting proposed changes to topics," on the page "Office VBA support and feedback," 1/8/20, https://docs.microsoft.com/en-us/office/vba/articles/feedback-support. 

But I still see an Edit button in the VBA documentation.  

Maybe can you point me to a blog post or other explanation about the current policy?