### PR TITLE
Delete heading to make consistent with other enums

### DIFF
--- a/api/Word.wdcolumnwidth.md
+++ b/api/Word.wdcolumnwidth.md
@@ -9,10 +9,7 @@ localization_priority: Normal
 
 # WdColumnWidth enumeration (Word)
 
-Constants that represent column width in reading layout, passed to and returned by the [View.ColumnWidth](Word.view.columnwidth.md) property.
-
-
-## Members
+Specifies the column width in reading layout, passed to and returned by the [View.ColumnWidth](Word.view.columnwidth.md) property.
 
 
 


### PR DESCRIPTION
Also, begin the description with "Specifies..." like other enumerations.