### PR TITLE
Delete heading to make consistent with other enums

### DIFF
--- a/api/Word.xlseriesnamelevel.md
+++ b/api/Word.xlseriesnamelevel.md
@@ -9,10 +9,7 @@ localization_priority: Normal
 
 # XlSeriesNameLevel enumeration (Word)
 
-Series-name-level constants passed to and returned by the [Chart.SeriesNameLevel](Word.chart.seriesnamelevel.md) property.
-
-
-## Members
+Specifies series-name-level constants passed to and returned by the [Chart.SeriesNameLevel](Word.chart.seriesnamelevel.md) property.
 
 
 


### PR DESCRIPTION
Also, begin the description with "Specifies..." like other enumerations.