### PR TITLE
Delete heading to make consistent with other enums

### DIFF
--- a/api/Word.xlparentdatalabeloptions.md
+++ b/api/Word.xlparentdatalabeloptions.md
@@ -9,10 +9,7 @@ localization_priority: Normal
 
 # XlParentDataLabelOptions enumeration (Word)
 
-Constants passed to and returned by the **Series.ParentDataLabelOption** property.
-
-
-## Members
+Specifies constants passed to and returned by the **Series.ParentDataLabelOption** property.
 
 
 


### PR DESCRIPTION
Also, begin the description with "Specifies..." like other enumerations.