### PR TITLE
update description for bit version incompatibility

### DIFF
--- a/Language/Reference/User-Interface-Help/error-in-loading-dll-error-48.md
+++ b/Language/Reference/User-Interface-Help/error-in-loading-dll-error-48.md
@@ -26,7 +26,7 @@ A [dynamic link library (DLL)](../../Glossary/vbe-glossary.md#dynamic-link-libra
     
 - The DLL or one of the referenced DLLs isn't in a directory specified by your path. Move the DLL to a referenced directory or place its current directory on the path.
 
-- The DLL is not the same bit version as the operating enviroment of VBA.
+- The DLL is not the same bit version as the operating environment of VBA. For more information about bit version incompatibility, see [Mixing 32 and 64 bit DLLs](https://software.intel.com/en-us/forums/intel-fortran-compiler/topic/515978) on the Intel developer forum.
 
 For additional information, select the item in question and press F1 (in Windows) or HELP (on the Macintosh).
 

--- a/Language/Reference/User-Interface-Help/error-in-loading-dll-error-48.md
+++ b/Language/Reference/User-Interface-Help/error-in-loading-dll-error-48.md
@@ -25,7 +25,8 @@ A [dynamic link library (DLL)](../../Glossary/vbe-glossary.md#dynamic-link-libra
 - The DLL references another DLL that isn't present. Obtain the referenced DLL and make it available to the other DLL.
     
 - The DLL or one of the referenced DLLs isn't in a directory specified by your path. Move the DLL to a referenced directory or place its current directory on the path.
-    
+
+- The DLL is not the same bit version as the operating enviroment of VBA.
 
 For additional information, select the item in question and press F1 (in Windows) or HELP (on the Macintosh).
 


### PR DESCRIPTION
At my work a colleague tried to update an excel file to use a dll instead of writing the functionality in vba.
When directly referering to the dll path in the **Lib** it gave 48, I tried then to search the internet for the issue, until I thought about the issue(text now added).
I looked it up and found this qoute: "...using 64-bit Excel you will need to provide 64-bit DLLs..."
From this forum thread: https://software.intel.com/en-us/forums/intel-fortran-compiler/topic/515978

I then also tested this out to be correct as the 32bit dll worked on 32bit excel.