### PR TITLE
Include newer versions of Office in the note

### DIFF
--- a/Language/Concepts/Getting-Started/64-bit-visual-basic-for-applications-overview.md
+++ b/Language/Concepts/Getting-Started/64-bit-visual-basic-for-applications-overview.md
@@ -12,7 +12,7 @@ localization_priority: Priority
 Microsoft Visual Basic for Applications (VBA) is the version of Visual Basic that ships with Microsoft Office. In Microsoft Office 2010, VBA includes language features that enable VBA code to run correctly in both 32-bit and 64-bit environments.
 
 > [!NOTE] 
-> By default, Office 2010 installs the 32-bit version. You must explicitly choose to install the 64-bit version during setup.
+> By default, Office 2010, 2013 and 2016 install the 32-bit version. You must explicitly choose to install the 64-bit version during setup. Starting with Office 2019 and Microsoft 365, the default is the 64-bit version.
 
 Running VBA code that was written before the Office 2010 release (VBA version 6 and earlier) on a 64-bit platform can result in errors if the code is not modified to run in 64-bit versions of Office. Errors will result because VBA version 6 and earlier implicitly targets 32-bit platforms, and typically contains **[Declare statements](../../reference/user-interface-help/declare-statement.md)** that call into the Windows API by using 32-bit data types for pointers and handles. Because VBA version 6 and earlier does not have a specific data type for pointers or handles, it uses the **Long** data type, which is a 32-bit 4-byte data type, to reference pointers and handles. Pointers and handles in 64-bit environments are 8-byte 64-bit quantities. These 64-bit quantities cannot be held in 32-bit data types.
 


### PR DESCRIPTION
Source: https://support.microsoft.com/en-us/office/choose-between-the-64-bit-or-32-bit-version-of-office-2dee7807-8f95-4d0c-b5fe-6c6f49b8d261#32or64Bit=Newer_Versions

It is clear from the page above that 365 and 2019 use the 64-bit version by default and that 2010 and 2016 use the 32-bit version by default.
I wasn't sure about 2013 since the tab for 2013 says "We recommend the 32-bit version of Office for most users..." but this doesn't mean it's the default.

So, I double-checked here: https://support.microsoft.com/en-us/office/download-and-install-or-reinstall-office-2016-or-office-2013-7c695b06-6d1a-4917-809c-98ce43f86479#InstallSteps=Office_2013_for_PC

It states : "To install Office in a different language, or to install the 64-bit version, select the link Other options."
Hence, because 64 bits it's part of the other options, the default for 2013 is the 32-bit version.

It actually makes sense because it would have been weird if 2013's default became the 64-bit version and 2016 went back to a 32-bit default version.