### PR TITLE
Update instrrev-function.md

### DIFF
--- a/Language/Reference/User-Interface-Help/instrrev-function.md
+++ b/Language/Reference/User-Interface-Help/instrrev-function.md
@@ -52,11 +52,13 @@ The _compare_ argument can have the following values:
 |_stringmatch_ is **Null**|**Null**|
 |_stringmatch_ is not found|0|
 |_stringmatch_ is found within _stringcheck_|Position at which match is found|
-|_start_ > **Len**(_stringmatch_)|0|
+|_start_ > **Len**(_stringcheck_)|0|
 
 ## Remarks
 
 Note that the syntax for the **InstrRev** function is not the same as the syntax for the **[Instr](instr-function.md)** function.
+
+**InstrRev** will not find an instance of _stringmatch_ unless the position of the end character of _stringmatch_ is less than or equal to _start_. 
 
 ## See also
 


### PR DESCRIPTION
InstrRev does not return 0 if  start > Len(stringmatch) - it returns 0 if start > Len(stringcheck) - easy enough to prove: InstrRev("TEST", "E", 4) will return a value of 2, not zero, even though start > Len("E"). But InstrRev("TEST", "E", 5) does return 0, because now start > Len("TEST")

Much more subtle behavior is InstrRev will not find an instance of stringmatch unless the position of the end character of stringmatch is less than or equal to start. An example demonstrates: InstrRev("THIS IS A TEST STRING", "TEST", 13) returns a value of 0, but InstrRev("THIS IS A TEST STRING", "TEST", 14) returns a value of 11.