### PR TITLE
Document the bug with custom document properties

### DIFF
--- a/api/PowerPoint.Presentation.CustomDocumentProperties.md
+++ b/api/PowerPoint.Presentation.CustomDocumentProperties.md
@@ -16,6 +16,9 @@ localization_priority: Normal
 
 Returns a **DocumentProperties** collection that represents all the custom document properties for the specified presentation. Read-only.
 
+> [!NOTE] 
+> All custom document properties will be lost when user uses the **Design Ideas** to change the look of a slide in the presentation.
+
 
 ## Syntax
 


### PR DESCRIPTION
For reference see https://stackoverflow.com/questions/55378132/why-does-powerpoint-reset-clear-the-customdocumentproperties-when-using-design