### PR TITLE
wdWrapFront=3. Change the topic or the enum?

### DIFF
--- a/api/Word.WdWrapType.md
+++ b/api/Word.WdWrapType.md
@@ -24,7 +24,7 @@ Specifies how to wrap text around a shape.
 | **wdWrapTight**|1|Wraps text close to the shape.|
 | **wdWrapTopBottom**|4|Places text above and below the shape.|
 | **wdWrapBehind**|5|Places shape behind text.|
-| **wdWrapFront**|6|Places shape in front of text.|
+| **wdWrapFront**|3|Places shape in front of text. See also **wdWrapNone**.|
 
 ## Remarks
 
@@ -32,6 +32,7 @@ Used with the **Type** property of the **WrapFormat** object. You can view what 
 
 
 > [!NOTE] 
->  **wdWrapSquare**, **wdWrapTight**, and **wdWrapThrough** all function in essentially the same way.
+>  **wdWrapSquare**, **wdWrapTight**, and **wdWrapThrough** all function in essentially the same way. \
+>  **wdWrapFront** and **wdWrapNone** have the same effect and have the value 3. The value 6 has the same effect as 3. 
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]


### PR DESCRIPTION
wdWrapFront = 3, not 6, so I edited the topic. (I'm running Microsoft Office Professional 2016.) 

However, should wdWrapFront = 6 and should the enum code be changed? Is this a bug? 

If the enum code were changed, Word wouldn't be affected, because both 3 and 6 work the same. To test, I stepped through the following code. 

```vb
Sub TestShapeWrapFormatTypeValues()
    Dim shp As Shape
    Set shp = ActiveDocument.Shapes(1)
    shp.WrapFormat.Type = 1
    shp.WrapFormat.Type = 3
    shp.WrapFormat.Type = 1
    shp.WrapFormat.Type = 6
    shp.WrapFormat.Type = 1
End Sub
```