### PR TITLE
AppleScriptTask.md: "mkdir" not "mk dir"

### DIFF
--- a/Office-Mac/AppleScriptTask.md
+++ b/Office-Mac/AppleScriptTask.md
@@ -34,7 +34,7 @@ The following are the [bundle id] values for Excel, PowerPoint, and Word:
 For example, the corresponding AppleScript for Excel would be in a file named `MyAppleScriptFile.applescript` that is in ~/Library/Application Scripts/com.microsoft.Excel/.
 
 > [!IMPORTANT] 
-> The folders such as `com.microsoft.Excel` may not exist. In that case, just create them by using a standard **mk dir** command. 
+> The folders such as `com.microsoft.Excel` may not exist. In that case, just create them by using a standard **mkdir** command. 
 
 The following is an example of a handler.
 


### PR DESCRIPTION
The shell command to create a directory is called "mkdir" not "mk dir". Remove the extraneous space.