### PR TITLE
Update Access.DoCmd.SendObject.md

### DIFF
--- a/api/Access.DoCmd.SendObject.md
+++ b/api/Access.DoCmd.SendObject.md
@@ -87,22 +87,18 @@ Public Function CreateEmailWithOutlook( _
 
     ' Define app variable and get Outlook using the "New" keyword
     Dim olApp As New Outlook.Application
-    Dim olMailItem As Outlook.MailItem  ' An Outlook Mail item
+    Dim olEmail As Outlook.MailItem  ' An Outlook Mail item
  
     ' Create a new email object
-    Set olMailItem = olApp.CreateItem(olMailItem)
+    Set olEmail = olApp.CreateItem(olMailItem)
 
     ' Add the To/Subject/Body to the message and display the message
-    With olMailItem
+    With olEmail
         .To = MessageTo
         .Subject = Subject
         .Body = MessageBody
         .Display    ' To show the email message to the user
     End With
-
-    ' Release all object variables
-    Set olMailItem = Nothing
-    Set olApp = Nothing
 
 End Function
 ```
@@ -119,22 +115,18 @@ Public Function SendEmailWithOutlook( _
 
     ' Define app variable and get Outlook using the "New" keyword
     Dim olApp As New Outlook.Application
-    Dim olMailItem As Outlook.MailItem  ' An Outlook Mail item
+    Dim olEmail As Outlook.MailItem  ' An Outlook Mail item
  
     ' Create a new email object
-    Set olMailItem = olApp.CreateItem(olMailItem)
+    Set olEmail = olApp.CreateItem(olMailItem)
 
     ' Add the To/Subject/Body to the message and display the message
-    With olMailItem
+    With olEmail
         .To = MessageTo
         .Subject = Subject
         .Body = MessageBody
         .Send       ' Send the message immediately
     End With
-
-    ' Release all object variables
-    Set olMailItem = Nothing
-    Set olApp = Nothing
 
 End Function
 ```


### PR DESCRIPTION
`Dim olMailItem As Outlook.MailItem` is shadowing the [OlItemType](`https://docs.microsoft.com/en-us/office/vba/api/Outlook.OlItemType) enum member `olMailItem`.