### PR TITLE
Add that the default for a new style is paragraph

### DIFF
--- a/api/Word.Styles.Add.md
+++ b/api/Word.Styles.Add.md
@@ -28,7 +28,7 @@ _expression_ Required. A variable that represents a **[Styles](Word.styles.md)**
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
 |_Name_|Required|**String**|The new style name.|
-|_Type_|Optional|**[WdStyleType](word.wdstyletype.md)**|Can be one of the **WdStyleType** constants.|
+|_Type_|Optional|**[WdStyleType](word.wdstyletype.md)**|Can be one of the **WdStyleType** constants. The default is paragraph style.|
 
 ## Return value
 


### PR DESCRIPTION
To test, run these lines in the immediate window.

```vb
ActiveDocument.Styles.Add "test"
? ActiveDocument.Styles("test").Type
```

Type 1 means paragraph style. See [WdStyleType enumeration](https://docs.microsoft.com/en-us/office/vba/api/word.wdstyletype).