### PR TITLE
Include missing method call

### DIFF
--- a/Language/Reference/User-Interface-Help/createobject-function.md
+++ b/Language/Reference/User-Interface-Help/createobject-function.md
@@ -126,6 +126,8 @@ Set xlApp = CreateObject("excel.application")
 xlApp.Visible = True
     ' Use xlApp to access Microsoft Excel's 
     ' other objects.
+    ' Closes the application using the Quit method
+xlApp.Quit    
 
 ```
 


### PR DESCRIPTION
Instructions state `Quit` method invoked/called to close.