### PR TITLE
Improve internal references for Workbook.Connections

### DIFF
--- a/api/Excel.Connections.Add.md
+++ b/api/Excel.Connections.Add.md
@@ -32,7 +32,7 @@ _expression_ A variable that represents a **[Connections](Excel.Connections.md)*
 | _Description_|Required| **String**|Brief description about the connection.|
 | _ConnectionString_|Required| **Variant**|The connection string.|
 | _CommandText_|Required| **Variant**|The command text to create the connection.|
-| _lCmdtype_|Optional| **Variant**|Command type.|
+| _lCmdtype_|Optional| (**XlCmdType**)[Excel.XlCmdType.md]|Command type.|
 | _CreateModelConnection_|Optional| **Boolean**|Specifies whether to create a connection to the PowerPivot model.|
 | _ImportRelationships_|Optional| **Boolean**|Specifies whether to import any existing relationships.|
 

--- a/api/Excel.Connections.Add.md
+++ b/api/Excel.Connections.Add.md
@@ -32,7 +32,7 @@ _expression_ A variable that represents a **[Connections](Excel.Connections.md)*
 | _Description_|Required| **String**|Brief description about the connection.|
 | _ConnectionString_|Required| **Variant**|The connection string.|
 | _CommandText_|Required| **Variant**|The command text to create the connection.|
-| _lCmdtype_|Optional| (**XlCmdType**)[Excel.XlCmdType.md]|Command type.|
+| _lCmdtype_|Optional| [**XlCmdType**](Excel.XlCmdType.md)|Command type.|
 | _CreateModelConnection_|Optional| **Boolean**|Specifies whether to create a connection to the PowerPivot model.|
 | _ImportRelationships_|Optional| **Boolean**|Specifies whether to import any existing relationships.|
 

--- a/api/Excel.Workbook.Connections.md
+++ b/api/Excel.Workbook.Connections.md
@@ -14,7 +14,7 @@ localization_priority: Normal
 
 # Workbook.Connections property (Excel)
 
-Establishes a connection between the workbook and an ODBC or an OLEDB data source and refreshes the data without prompting the user. Read-only.
+Returns a [Connections](Excel.Connections.md) object that is a container for connections between the workbook and data sources such as ODBC, OLEDB, etc., that can refresh the data without prompting the user. Read-only.
 
 
 ## Syntax


### PR DESCRIPTION
* Workbook.Connections property should reference the object type Connections
* Connections.Add should reference the argument type enum XlCmdType