### PR TITLE
Corrected wording

### DIFF
--- a/api/Access.Application.Nz.md
+++ b/api/Access.Application.Nz.md
@@ -38,7 +38,7 @@ Variant
 
 ## Remarks
 
-If the _Value_ of the variant argument is **Null**, the **Nz** function returns an unassigned **Variant**, the special value **[Empty](../language/glossary/vbe-glossary.md#empty)**. In VBA, **Empty** evaluates the number zero or a zero-length string, depending on whether the context indicates that the _Value_ should be a number or a string. For example:
+If the _Value_ of the variant argument is **Null**, the **Nz** function returns an unassigned **Variant**, the special value **[Empty](../language/glossary/vbe-glossary.md#empty)**. In VBA, when evaluated, **Empty** will result in either the number zero or a zero-length string, depending on whether the context indicates that the _Value_ should be a number or a string. For example:
 
 ```vb
 Nz(Null) + 2    ' returns 2


### PR DESCRIPTION
The previous modification (removing "to") resulted in meaningless wording. This modification will correct that.