### PR TITLE
Update dir-function.md

### DIFF
--- a/Language/Reference/User-Interface-Help/dir-function.md
+++ b/Language/Reference/User-Interface-Help/dir-function.md
@@ -46,7 +46,7 @@ The _attributes_ [argument](../../Glossary/vbe-glossary.md#argument) settings ar
 
 ## Remarks
 
-In Microsoft Windows, **Dir** supports the use of multiple character (**\***) and single character (**?**) wildcards to specify multiple files. On the Macintosh, these characters are treated as valid file name characters and can't be used as wildcards to specify multiple files.
+In Microsoft Windows and macOS, **Dir** supports the use of multiple character (**\***) and single character (**?**) wildcards to specify multiple files.
 
 Because the Macintosh doesn't support the wildcards, use the file type to identify groups of files. You can use the **MacID** function to specify file type instead of using the file names. For example, the following statement returns the name of the first TEXT file in the current folder:
 
@@ -70,10 +70,8 @@ You must specify _pathname_ the first time you call the **Dir** function, or an 
 
 You can change to a new _pathname_ without retrieving all of the file names that match the current _pathname_. However, you can't call the **Dir** function recursively. Calling **Dir** with the **vbDirectory** attribute does not continually return subdirectories.
 
-With Excel for Mac 2016, the initial **Dir** function call will succeed. Subsequent calls to iterate through the specified directory will cause an error, however. This is a known bug unfortunately.
-
 > [!TIP] 
-> Because file names are retrieved in no particular order, you may want to store returned file names in an array, and then sort the array.
+> Because file names are retrieved in case-insensitive order on Windows and case-sensitive order on macOS, you may want to store returned file names in an array, and then sort the array.
 
 ## See also
 


### PR DESCRIPTION
1. The part about wildcards not working on macOS used to be true but is no longer the case.
1. The part about Excel 2016 subsequent calls working on macOS used to be true but is no longer the case.
2. File names are in fact retrieved in a predictable  order, just not the same order between Windows and macOS.