### PR TITLE
Correct syntax line.

### DIFF
--- a/api/Word.Range.Delete.md
+++ b/api/Word.Range.Delete.md
@@ -19,7 +19,7 @@ Deletes the specified number of characters or words.
 
 ## Syntax
 
-_expression_.**Delete**( `_Unit_` , `_Count_` )
+_expression_.**Delete**(\[_Unit_\], \[_Count_\])
 
 _expression_ Required. A variable that represents a **[Range](Word.Range.md)** object.
 


### PR DESCRIPTION
Removed inline code markers and added square brackets to indicate optional parameters. This brings it in line with documentation standard.