### PR TITLE
Update PowerPoint.Presentation.DefaultLanguageID.md

### DIFF
--- a/api/PowerPoint.Presentation.DefaultLanguageID.md
+++ b/api/PowerPoint.Presentation.DefaultLanguageID.md
@@ -31,7 +31,7 @@ MsoLanguageID
 
 ## Remarks
 
-When you set the  **DefaultLanguageID** property for a presentation, you set it for all subsequent new presentations as well.
+When you set the  **DefaultLanguageID** property for a presentation, you set it for all open and all subsequent new presentations as well.
 
 The value of the  **DefaultLanguageID** property can be one of these **MsoLanguageID** constants.
 
@@ -218,7 +218,7 @@ The value of the  **DefaultLanguageID** property can be one of these **MsoLangua
 
 ## Example
 
-This example sets the default language for the active presentation, and all subsequent new presentations, to German.
+This example sets the default language for the active presentation, all open presentations, and all subsequent new presentations, to German.
 
 
 ```vb


### PR DESCRIPTION
Setting PowerPoint.Presentation.DefaultLanguageID also changes the DefaultLanguageID for all currently open presentations, not only the active presentation and new presentations. As this behavior is not to be expected it should be documented.