### PR TITLE
Update Word.Range.ComputeStatistics.md

### DIFF
--- a/api/Word.Range.ComputeStatistics.md
+++ b/api/Word.Range.ComputeStatistics.md
@@ -36,6 +36,17 @@ _expression_ Required. A variable that represents a **[Range](Word.Range.md)** o
 
 Some of the constants listed above may not be available to you, depending on the language support (U.S. English, for example) that you've selected or installed.
 
+The Statistic returned for Table.Cell Range will be inaccurate due to the end-of-cell marker interfering with the Statistic. Truncating the Range to remove the end-of-cell-marker will result in the correct Statistic value.
+
+```vb
+Set cell = Documents("Report.doc").Tables(1).Cell(1, 1)
+Set myRange = cell.Range
+lineCount = myRange.ComputeStatistics(Statistic:=wdStatisticLines) 'Returns 0
+rng.MoveEnd wdCharacter, -1 
+lineCount = myRange.ComputeStatistics(Statistic:=wdStatisticLines)
+MsgBox "The first cell contains " & lineCount _ 
+ & " lines."
+```
 
 ## Example
 


### PR DESCRIPTION
This is a known problem with the statistics being thrown off by the end-of-cell marker. Please include this so that it is known for the Range method. 
Or create a new page specifically for Table.Cell.Range.ComputeStatistics where this can be shown.

https://stackoverflow.com/a/70426205/1623971