### PR TITLE
Change Method name from AddFolders to Add

### DIFF
--- a/Language/Reference/User-Interface-Help/folder-object.md
+++ b/Language/Reference/User-Interface-Help/folder-object.md
@@ -41,7 +41,7 @@ End Sub
 
 |Method|Description|
 |:-----|:----------|
-|[AddFolders](addfolders-method.md) | Adds a new **Folder** to a **Folders** collection.|
+|[Add](addfolders-method.md) | Adds a new **Folder** to a **Folders** collection.|
 |[Copy](copy-method-visual-basic-for-applications.md)|Copies a specified folder from one location to another. |
 |[CreateTextFile](createtextfile-method.md)|Creates a new text file in the specified folder and returns a TextStream object to access the file. |
 |[Delete](delete-method-visual-basic-for-applications.md)|Deletes a specified folder. |


### PR DESCRIPTION
i have already created a FileSystemObject then using the getFolder method i have returned a Folder object
Then I created a Collection of folders using the SubFolders method
I tried a lot using the AddFolders method (I used the same method name mentioned on the page)
But all my attempts failed
After reviewing many references, it was found that the name of the method is Add, not AddFolder
So I modified the method name from AddFolders to Add