### PR TITLE
Validation: Absolute links, duplicate image alt text, and preserve view error fixes.

### DIFF
--- a/access/Concepts/Miscellaneous/cannot-open-a-database-created-with-a-previous-version-of-your-applicationerror.md
+++ b/access/Concepts/Miscellaneous/cannot-open-a-database-created-with-a-previous-version-of-your-applicationerror.md
@@ -19,7 +19,7 @@ You tried to access a database that is in an outdated format. Compact the databa
 
 For information about how to compact and repair Access databases, see the following:
 
-- [DBEngine.CompactDatabase method (DAO)](https://docs.microsoft.com/office/client-developer/access/desktop-database-reference/dbengine-compactdatabase-method-dao)   
+- [DBEngine.CompactDatabase method (DAO)](/office/client-developer/access/desktop-database-reference/dbengine-compactdatabase-method-dao)   
 
 
     

--- a/access/Concepts/Miscellaneous/command-ado-for-visual-c-plus-plus-syntax.md
+++ b/access/Concepts/Miscellaneous/command-ado-for-visual-c-plus-plus-syntax.md
@@ -13,7 +13,7 @@ ms.localizationpriority: medium
 
 ## Methods
 
-[Cancel](https://docs.microsoft.com/office/client-developer/access/desktop-database-reference/cancel-method-ado)(void)
+[Cancel](/office/client-developer/access/desktop-database-reference/cancel-method-ado)(void)
 
 [CreateParameter](https://msdn.microsoft.com/library/cf080a0b-75d2-dcdf-2715-10af147358e9%28Office.15%29.aspx)(BSTR  _Name,_ DataTypeEnum _Type,_ ParameterDirectionEnum _Direction,_ long _Size,_ VARIANT _Value,_ _ADOParameter ** _ppiprm_ )
 

--- a/api/Access.CheckBox.md
+++ b/api/Access.CheckBox.md
@@ -20,7 +20,7 @@ This object corresponds to a check box on a form or report. This check box is a 
 
 |Control|Tool|
 |:------|:---|
-|![Check box](../images/t-chkbox_ZA06053977.gif)|![Check box](../images/chkbox_ZA06047229.gif)|
+|![Screenshot of the Address Control check box.](../images/t-chkbox_ZA06053977.gif)|![Screenshot of the check box that corresponds to the Check Box object.](../images/chkbox_ZA06047229.gif)|
 
 When you select or clear a check box that's bound to a Yes/No field, Microsoft Access displays the value in the underlying table according to the field's **Format** property (Yes/No, **True**/**False**, or On/Off).
 

--- a/api/Access.CommandButton.md
+++ b/api/Access.CommandButton.md
@@ -21,7 +21,7 @@ This object corresponds to a command button. A command button on a form can star
 
 |Control|Tool|
 |:------|:---|
-|![Command button](../images/t-cmdbtn_ZA06053979.gif)|![Command button](../images/command_ZA06047243.gif)|
+|![Screenshot of the Print Form command button.](../images/t-cmdbtn_ZA06053979.gif)|![Screenshot of the command button that corresponds to the Command Button object.](../images/command_ZA06047243.gif)|
 
 You can display text on a command button by setting its **Caption** property, or you can display a picture by setting its **Picture** property.
 

--- a/api/Access.Entities.md
+++ b/api/Access.Entities.md
@@ -25,7 +25,7 @@ Use the **[Entities](Access.WebService.Entities.md)** property to return the ent
 
 Use the **Item** property to return an **[Entity](Access.Entity.md)** object.
 
-For more information about external content types, see [What Are External Content Types](https://docs.microsoft.com/previous-versions/office/developer/sharepoint-2010/ee556391(v=office.14)).
+For more information about external content types, see [What Are External Content Types](/previous-versions/office/developer/sharepoint-2010/ee556391(v=office.14)).
 
 
 ## Properties

--- a/api/Access.Entity.md
+++ b/api/Access.Entity.md
@@ -25,7 +25,7 @@ Use the **[Operations](Access.Operations.md)** property to return the operations
 
 A Data Service data connection may contain one or more entities. Each entity specifies an external content type. Used throughout the functionality and services offered by Business Connectivity Services, external content types are reusable metadata descriptions of connectivity information and data definitions plus the behaviors that you want to apply to a certain category of external data. 
 
-For more information about external content types, see [What Are External Content Types](https://docs.microsoft.com/previous-versions/office/developer/sharepoint-2010/ee556391(v=office.14)).
+For more information about external content types, see [What Are External Content Types](/previous-versions/office/developer/sharepoint-2010/ee556391(v=office.14)).
 
 
 ## Properties

--- a/api/Access.TextBox.KeyboardLanguage.md
+++ b/api/Access.TextBox.KeyboardLanguage.md
@@ -25,13 +25,13 @@ _expression_ A variable that represents a **[TextBox](Access.TextBox.md)** objec
 
 Valid values for this property are 0 (zero), which corresponds to the default system language, or _plid_ + 2, where _plid_ is the primary language ID of a language installed on the current system. For example, the primary language ID of English is 9, so the corresponding **KeyboardLanguage** setting is 11. 
 
-For a list of languages and their primary language IDs, see [Language Identifier Constants and Strings](https://docs.microsoft.com/windows/desktop/Intl/language-identifier-constants-and-strings). An exception to this list is Traditional Chinese, which is represented by the value 200.
+For a list of languages and their primary language IDs, see [Language Identifier Constants and Strings](/windows/desktop/Intl/language-identifier-constants-and-strings). An exception to this list is Traditional Chinese, which is represented by the value 200.
 
 Setting this property to a language that is not installed may either have no effect or cause an error.
 
 ## See also
 
-- [Language Identifiers](https://docs.microsoft.com/windows/desktop/intl/language-identifiers)
+- [Language Identifiers](/windows/desktop/intl/language-identifiers)
 
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Excel.OLEDBConnection.LocaleID.md
+++ b/api/Excel.OLEDBConnection.LocaleID.md
@@ -31,7 +31,7 @@ _expression_ A variable that represents an **[OLEDBConnection](Excel.OLEDBConnec
 
 ## Remarks
 
-Before you set the **LocaleID** property to a new locale, you must set the **[RetrieveInOfficeUILang](Excel.OLEDBConnection.RetrieveInOfficeUILang.md)** property to **False**. For more information about valid Locale ID (LCID) values, see the [LCID-Locale Mapping Table](https://docs.microsoft.com/openspecs/windows_protocols/ms-adts/a29e5c28-9fb9-4c49-8e43-4b9b8e733a05).
+Before you set the **LocaleID** property to a new locale, you must set the **[RetrieveInOfficeUILang](Excel.OLEDBConnection.RetrieveInOfficeUILang.md)** property to **False**. For more information about valid Locale ID (LCID) values, see the [LCID-Locale Mapping Table](/openspecs/windows_protocols/ms-adts/a29e5c28-9fb9-4c49-8e43-4b9b8e733a05).
 
 
 ## Example

--- a/api/Excel.Range.ConvertToLinkedDataType.md
+++ b/api/Excel.Range.ConvertToLinkedDataType.md
@@ -27,7 +27,7 @@ _expression_ A variable that represents a **[Range](Excel.Range(Object).md)** ob
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
 | _ServiceID_|Required| **Long**|The ID of the service that will provide the linked entity.|
-| _LanguageCulture_|Required| **String**|A string representing the [LCID](https://docs.microsoft.com/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c) of the language and culture that you would like to use for the linked entity. |
+| _LanguageCulture_|Required| **String**|A string representing the [LCID](/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c) of the language and culture that you would like to use for the linked entity. |
 
 ## Remarks
 

--- a/api/Excel.Range.Formula.md
+++ b/api/Excel.Range.Formula.md
@@ -27,7 +27,7 @@ _expression_ A variable that represents a **[Range](excel.range(object).md)** ob
 In Dynamic Arrays enabled Excel, Range.Formula2 supercedes Range.Formula. Range.Formula will continue to be supported to maintain backcompatibility. A discussion on Dynamic Arrays and Range.Formula2 can be found here. 
 
 ## See also
-**[Range.Formula2](https://docs.microsoft.com/office/vba/api/excel.range.formula2)** property
+**[Range.Formula2](/office/vba/api/excel.range.formula2)** property
 
 This property is not available for OLAP data sources.
 

--- a/api/Excel.Range.SetCellDataTypeFromCell.md
+++ b/api/Excel.Range.SetCellDataTypeFromCell.md
@@ -27,7 +27,7 @@ _expression_ A variable that represents the **[Range](excel.range(object).md)** 
 |Name|Required/Optional|Data type|Description|
 |:-----|:-----|:-----|:-----|
 | _Range_|Required| **Range**|The range _from_ which you want to copy the Linked data type. If the range has more than one cell in it, only the upper-left cell will be used. |
-| _LanguageCulture_|Required| **String**|A string representing the [LCID](https://docs.microsoft.com/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c) of the language and culture that you would like to use for the linked entity. |
+| _LanguageCulture_|Required| **String**|A string representing the [LCID](/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c) of the language and culture that you would like to use for the linked entity. |
 
 ## Example
 

--- a/api/Excel.Series.InvertColorIndex.md
+++ b/api/Excel.Series.InvertColorIndex.md
@@ -31,7 +31,7 @@ _expression_ A variable that represents a **[Series](Excel.Series(object).md)** 
 
 ## Remarks
 
-The **InvertColorIndex** property enables you to set the fill color for negative data points as a color index value from 0 to 56. For more information about color index values, see [Adding color to Excel 2007 worksheets by using the ColorIndex property](https://docs.microsoft.com/previous-versions/office/developer/office-2007/cc296089(v=office.12)). 
+The **InvertColorIndex** property enables you to set the fill color for negative data points as a color index value from 0 to 56. For more information about color index values, see [Adding color to Excel 2007 worksheets by using the ColorIndex property](/previous-versions/office/developer/office-2007/cc296089(v=office.12)). 
 
 Instead of using the **InvertColorIndex** property, you can use the **[InvertColor](Excel.Series.InvertColor.md)** property, which enables you to set the color as a specific numeric, hexadecimal, octal, or RGB color value.
 

--- a/api/Excel.Workbook.ExportAsFixedFormat.md
+++ b/api/Excel.Workbook.ExportAsFixedFormat.md
@@ -44,6 +44,6 @@ ActiveWorkbook.ExportAsFixedFormat Type:=xlTypePDF FileName:="sales.pdf" Quality
 ```
 ## Remarks 
 
-Until _second RMID_, Office will default to creating unprotected PDFs (when _Type_ is _xlTypePDF_). After that time, Office will default to creating protected PDFs. For more information, see [Manage sensitivity labels in Office apps](/microsoft-365/compliance/sensitivity-labels-office-apps?view=o365-worldwide#pdf-support).
+Until _second RMID_, Office will default to creating unprotected PDFs (when _Type_ is _xlTypePDF_). After that time, Office will default to creating protected PDFs. For more information, see [Manage sensitivity labels in Office apps](/microsoft-365/compliance/sensitivity-labels-office-apps?view=o365-worldwide#pdf-support&preserve-view=true).
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Excel.Worksheet.Protect.md
+++ b/api/Excel.Worksheet.Protect.md
@@ -48,7 +48,7 @@ _expression_ A variable that represents a **[Worksheet](Excel.Worksheet.md)** ob
 ## Remarks
 
 >[!NOTE]
-> In [previous versions](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2010/s1cay0kc(v=vs.100)#remarks), if you apply this method with the **UserInterfaceOnly** argument set to **True** and then save the workbook, the entire worksheet (not just the interface) will be fully protected when you reopen the workbook. To re-enable the user interface protection after the workbook is opened, you must again apply this method with **UserInterfaceOnly** set to **True**.
+> In [previous versions](/previous-versions/visualstudio/visual-studio-2010/s1cay0kc(v=vs.100)#remarks), if you apply this method with the **UserInterfaceOnly** argument set to **True** and then save the workbook, the entire worksheet (not just the interface) will be fully protected when you reopen the workbook. To re-enable the user interface protection after the workbook is opened, you must again apply this method with **UserInterfaceOnly** set to **True**.
 
 If you want to make changes to a protected worksheet, it is possible to use the **Protect** method on a protected worksheet if the password is supplied. Also, another method would be to unprotect the worksheet, make the necessary changes, and then protect the worksheet again.
 

--- a/api/Excel.WorksheetFunction.BesselJ.md
+++ b/api/Excel.WorksheetFunction.BesselJ.md
@@ -44,7 +44,7 @@ If n is nonnumeric, **BesselJ** generates an error value.
     
 If n < 0, **BesselJ** generates an error value.
     
-The n-th order Bessel function of the variable x is ![Bessel function](../images/awfbslj1_ZA06051116.gif) where ![Bessel function](../images/awfbslj2_ZA06051117.gif) is the Gamma function. 
+The n-th order Bessel function of the variable x is ![Screenshot that is showing the Bessel function.](../images/awfbslj1_ZA06051116.gif) where ![Screenshot that is showing the Gamma function.](../images/awfbslj2_ZA06051117.gif) is the Gamma function. 
     
 
 

--- a/api/Excel.WorksheetFunction.BesselJ.md
+++ b/api/Excel.WorksheetFunction.BesselJ.md
@@ -44,7 +44,7 @@ If n is nonnumeric, **BesselJ** generates an error value.
     
 If n < 0, **BesselJ** generates an error value.
     
-The n-th order Bessel function of the variable x is ![Screenshot that is showing the Bessel function.](../images/awfbslj1_ZA06051116.gif) where ![Screenshot that is showing the Gamma function.](../images/awfbslj2_ZA06051117.gif) is the Gamma function. 
+The n-th order Bessel function of the variable x is ![Screenshot that is showing the Bessel function.](../images/awfbslj1_ZA06051116.gif) where ![Screenshot of the Gamma function.](../images/awfbslj2_ZA06051117.gif) is the Gamma function. 
     
 
 

--- a/api/Excel.WorksheetFunction.BesselJ.md
+++ b/api/Excel.WorksheetFunction.BesselJ.md
@@ -44,7 +44,7 @@ If n is nonnumeric, **BesselJ** generates an error value.
     
 If n < 0, **BesselJ** generates an error value.
     
-The n-th order Bessel function of the variable x is ![Screenshot that is showing the Bessel function.](../images/awfbslj1_ZA06051116.gif) where ![Screenshot of the Gamma function.](../images/awfbslj2_ZA06051117.gif) is the Gamma function. 
+The n-th order Bessel function of the variable x is ![Screenshot of the Bessel function.](../images/awfbslj1_ZA06051116.gif) where ![Screenshot of the Gamma function.](../images/awfbslj2_ZA06051117.gif) is the Gamma function. 
     
 
 

--- a/api/Excel.WorksheetFunction.BinomDist.md
+++ b/api/Excel.WorksheetFunction.BinomDist.md
@@ -52,7 +52,7 @@ If probability_s < 0 or probability_s > 1, **BinomDist** generates an error.
     
 The binomial probability mass function is ![Screenshot of the binomial probability mass equation.](../images/awfbnmd1_ZA06051113.gif) where ![Screenshot of the COMBIN (n, x) equation.](../images/awfbnmd2_ZA06051114.gif) is COMBIN(n,x). 
 
-The cumulative binomial distribution is ![Screenshot that is showing the cumulative binomial distribution equation.](../images/awfbnmd3_ZA06051115.gif)
+The cumulative binomial distribution is ![Screenshot of the cumulative binomial distribution equation.](../images/awfbnmd3_ZA06051115.gif)
 
 
 

--- a/api/Excel.WorksheetFunction.BinomDist.md
+++ b/api/Excel.WorksheetFunction.BinomDist.md
@@ -50,7 +50,7 @@ If number_s < 0 or number_s > trials, **BinomDist** generates an error.
     
 If probability_s < 0 or probability_s > 1, **BinomDist** generates an error.
     
-The binomial probability mass function is ![Screenshot that is showing the binomial probability mass equation.](../images/awfbnmd1_ZA06051113.gif) where ![Screenshot that is showing the COMBIN (n, x) equation.](../images/awfbnmd2_ZA06051114.gif) is COMBIN(n,x). 
+The binomial probability mass function is ![Screenshot of the binomial probability mass equation.](../images/awfbnmd1_ZA06051113.gif) where ![Screenshot of the COMBIN (n, x) equation.](../images/awfbnmd2_ZA06051114.gif) is COMBIN(n,x). 
 
 The cumulative binomial distribution is ![Screenshot that is showing the cumulative binomial distribution equation.](../images/awfbnmd3_ZA06051115.gif)
 

--- a/api/Excel.WorksheetFunction.BinomDist.md
+++ b/api/Excel.WorksheetFunction.BinomDist.md
@@ -50,9 +50,9 @@ If number_s < 0 or number_s > trials, **BinomDist** generates an error.
     
 If probability_s < 0 or probability_s > 1, **BinomDist** generates an error.
     
-The binomial probability mass function is ![BPM function](../images/awfbnmd1_ZA06051113.gif) where ![BPM function](../images/awfbnmd2_ZA06051114.gif) is COMBIN(n,x). 
+The binomial probability mass function is ![Screenshot that is showing the binomial probability mass equation.](../images/awfbnmd1_ZA06051113.gif) where ![Screenshot that is showing the COMBIN (n, x) equation.](../images/awfbnmd2_ZA06051114.gif) is COMBIN(n,x). 
 
-The cumulative binomial distribution is ![BPM function](../images/awfbnmd3_ZA06051115.gif)
+The cumulative binomial distribution is ![Screenshot that is showing the cumulative binomial distribution equation.](../images/awfbnmd3_ZA06051115.gif)
 
 
 

--- a/api/Excel.WorksheetFunction.Binom_Dist.md
+++ b/api/Excel.WorksheetFunction.Binom_Dist.md
@@ -52,7 +52,7 @@ If probability_s < 0 or probability_s > 1, the **Binom_Dist** method generates a
     
 The binomial probability mass function is ![Screenshot of binomial probability mass equation.](../images/awfbnmd1_ZA06051113.gif) where ![Screenshot of COMBIN (n, x) equation.](../images/awfbnmd2_ZA06051114.gif) is COMBIN(n,x). 
 
-The cumulative binomial distribution is ![Screenshot showing the cumulative binomial distribution equation.](../images/awfbnmd3_ZA06051115.gif)
+The cumulative binomial distribution is ![Screenshot of the cumulative binomial distribution equation.](../images/awfbnmd3_ZA06051115.gif)
 
 
 

--- a/api/Excel.WorksheetFunction.Binom_Dist.md
+++ b/api/Excel.WorksheetFunction.Binom_Dist.md
@@ -50,9 +50,9 @@ If number_s < 0 or number_s > trials, the **Binom_Dist** method generates an err
     
 If probability_s < 0 or probability_s > 1, the **Binom_Dist** method generates an error.
     
-The binomial probability mass function is ![BPM function](../images/awfbnmd1_ZA06051113.gif) where ![BPM function](../images/awfbnmd2_ZA06051114.gif) is COMBIN(n,x). 
+The binomial probability mass function is ![Screenshot showing the binomial probability mass equation.](../images/awfbnmd1_ZA06051113.gif) where ![Screenshot showing the COMBIN (n, x) equation.](../images/awfbnmd2_ZA06051114.gif) is COMBIN(n,x). 
 
-The cumulative binomial distribution is ![BPM function](../images/awfbnmd3_ZA06051115.gif)
+The cumulative binomial distribution is ![Screenshot showing the cumulative binomial distribution equation.](../images/awfbnmd3_ZA06051115.gif)
 
 
 

--- a/api/Excel.WorksheetFunction.Binom_Dist.md
+++ b/api/Excel.WorksheetFunction.Binom_Dist.md
@@ -50,7 +50,7 @@ If number_s < 0 or number_s > trials, the **Binom_Dist** method generates an err
     
 If probability_s < 0 or probability_s > 1, the **Binom_Dist** method generates an error.
     
-The binomial probability mass function is ![Screenshot showing the binomial probability mass equation.](../images/awfbnmd1_ZA06051113.gif) where ![Screenshot showing the COMBIN (n, x) equation.](../images/awfbnmd2_ZA06051114.gif) is COMBIN(n,x). 
+The binomial probability mass function is ![Screenshot of binomial probability mass equation.](../images/awfbnmd1_ZA06051113.gif) where ![Screenshot of COMBIN (n, x) equation.](../images/awfbnmd2_ZA06051114.gif) is COMBIN(n,x). 
 
 The cumulative binomial distribution is ![Screenshot showing the cumulative binomial distribution equation.](../images/awfbnmd3_ZA06051115.gif)
 

--- a/api/Excel.WorksheetFunction.Combin.md
+++ b/api/Excel.WorksheetFunction.Combin.md
@@ -48,7 +48,7 @@ A combination is any set or subset of items, regardless of their internal order.
     
 The number of combinations is as follows, where number = n and number_chosen = k:
 
-> ![Screenshot showing a number of combinations where number equals n, and the number chosen equals k.](../images/awfcmbn1_ZA06051122.gif) &nbsp; where &nbsp; ![Screenshot that shows a number of combinations where number equals n, and the number chosen equals k.](../images/awfcmbn2_ZA06051123.gif)
+> ![Screenshot of a number of combinations where number equals n, and the number chosen equals k.](../images/awfcmbn1_ZA06051122.gif) &nbsp; where &nbsp; ![Screenshot of a number of combinations where number equals n, and the number chosen equals k.](../images/awfcmbn2_ZA06051123.gif)
 
 
     

--- a/api/Excel.WorksheetFunction.Combin.md
+++ b/api/Excel.WorksheetFunction.Combin.md
@@ -48,7 +48,7 @@ A combination is any set or subset of items, regardless of their internal order.
     
 The number of combinations is as follows, where number = n and number_chosen = k:
 
-> ![Formula](../images/awfcmbn1_ZA06051122.gif) &nbsp; where &nbsp; ![Formula](../images/awfcmbn2_ZA06051123.gif)
+> ![Screenshot showing a number of combinations where number equals n, and the number chosen equals k.](../images/awfcmbn1_ZA06051122.gif) &nbsp; where &nbsp; ![Screenshot that shows a number of combinations where number equals n, and the number chosen equals k.](../images/awfcmbn2_ZA06051123.gif)
 
 
     

--- a/api/Excel.WorksheetFunction.Erf.md
+++ b/api/Excel.WorksheetFunction.Erf.md
@@ -52,7 +52,7 @@ If upper_limit is negative, **Erf** returns the #NUM! error value.
 
 ![Screenshot of the erf method where the error function is the integral of the lower and upper limits.](../images/awferf1_ZA06051136.gif)
 
-![Second screenshot showing the erf method where the error function is the integral of the lower and upper limits.](../images/awferf2_ZA06051137.gif)
+![Second screenshot of the erf method where the error function is the integral of the lower and upper limits.](../images/awferf2_ZA06051137.gif)
 
 
 

--- a/api/Excel.WorksheetFunction.Erf.md
+++ b/api/Excel.WorksheetFunction.Erf.md
@@ -50,9 +50,9 @@ If upper_limit is nonnumeric, **Erf** returns the #VALUE! error value.
     
 If upper_limit is negative, **Erf** returns the #NUM! error value.
 
-![Formula](../images/awferf1_ZA06051136.gif)
+![Screenshot showing the erf method where the error function is the integral of the lower and upper limits.](../images/awferf1_ZA06051136.gif)
 
-![Formula](../images/awferf2_ZA06051137.gif)
+![Second screenshot showing the erf method where the error function is the integral of the lower and upper limits.](../images/awferf2_ZA06051137.gif)
 
 
 

--- a/api/Excel.WorksheetFunction.Erf.md
+++ b/api/Excel.WorksheetFunction.Erf.md
@@ -50,7 +50,7 @@ If upper_limit is nonnumeric, **Erf** returns the #VALUE! error value.
     
 If upper_limit is negative, **Erf** returns the #NUM! error value.
 
-![Screenshot showing the erf method where the error function is the integral of the lower and upper limits.](../images/awferf1_ZA06051136.gif)
+![Screenshot of the erf method where the error function is the integral of the lower and upper limits.](../images/awferf1_ZA06051136.gif)
 
 ![Second screenshot showing the erf method where the error function is the integral of the lower and upper limits.](../images/awferf2_ZA06051137.gif)
 

--- a/api/Excel.WorksheetFunction.ExponDist.md
+++ b/api/Excel.WorksheetFunction.ExponDist.md
@@ -51,7 +51,7 @@ If lambda ≤ 0, **ExponDist** returns the #NUM! error value.
     
 The equation for the probability density function is &nbsp; ![Screenshot of the probability density equation.](../images/awfxpnd1_ZA06051267.gif)
 
-The equation for the cumulative distribution function is &nbsp; ![Screenshot showing the cumulative distribution function.](../images/awfxpnd2_ZA06051268.gif)
+The equation for the cumulative distribution function is &nbsp; ![Screenshot of the cumulative distribution function.](../images/awfxpnd2_ZA06051268.gif)
 
 
 

--- a/api/Excel.WorksheetFunction.ExponDist.md
+++ b/api/Excel.WorksheetFunction.ExponDist.md
@@ -49,7 +49,7 @@ If x < 0, **ExponDist** returns the #NUM! error value.
     
 If lambda ≤ 0, **ExponDist** returns the #NUM! error value.
     
-The equation for the probability density function is &nbsp; ![Screenshot showing the probability density equation.](../images/awfxpnd1_ZA06051267.gif)
+The equation for the probability density function is &nbsp; ![Screenshot of the probability density equation.](../images/awfxpnd1_ZA06051267.gif)
 
 The equation for the cumulative distribution function is &nbsp; ![Screenshot showing the cumulative distribution function.](../images/awfxpnd2_ZA06051268.gif)
 

--- a/api/Excel.WorksheetFunction.ExponDist.md
+++ b/api/Excel.WorksheetFunction.ExponDist.md
@@ -49,9 +49,9 @@ If x < 0, **ExponDist** returns the #NUM! error value.
     
 If lambda ≤ 0, **ExponDist** returns the #NUM! error value.
     
-The equation for the probability density function is &nbsp; ![Formula](../images/awfxpnd1_ZA06051267.gif)
+The equation for the probability density function is &nbsp; ![Screenshot showing the probability density equation.](../images/awfxpnd1_ZA06051267.gif)
 
-The equation for the cumulative distribution function is &nbsp; ![Formula](../images/awfxpnd2_ZA06051268.gif)
+The equation for the cumulative distribution function is &nbsp; ![Screenshot showing the cumulative distribution function.](../images/awfxpnd2_ZA06051268.gif)
 
 
 

--- a/api/Excel.WorksheetFunction.Expon_Dist.md
+++ b/api/Excel.WorksheetFunction.Expon_Dist.md
@@ -45,9 +45,9 @@ If x < 0, **Expon_Dist** returns the #NUM! error value.
     
 If lambda ≤ 0, **Expon_Dist** returns the #NUM! error value.
     
-The equation for the probability density function is &nbsp; ![Formula](../images/awfxpnd1_ZA06051267.gif)
+The equation for the probability density function is &nbsp; ![Screenshot that is showing the probability density equation.](../images/awfxpnd1_ZA06051267.gif)
   
-The equation for the cumulative distribution function is &nbsp; ![Formula](../images/awfxpnd2_ZA06051268.gif)
+The equation for the cumulative distribution function is &nbsp; ![Screenshot that is showing the cumulative distribution equation.](../images/awfxpnd2_ZA06051268.gif)
 
 
     

--- a/api/Excel.WorksheetFunction.Expon_Dist.md
+++ b/api/Excel.WorksheetFunction.Expon_Dist.md
@@ -47,7 +47,7 @@ If lambda ≤ 0, **Expon_Dist** returns the #NUM! error value.
     
 The equation for the probability density function is &nbsp; ![Screenshot of the probability density equation.](../images/awfxpnd1_ZA06051267.gif)
   
-The equation for the cumulative distribution function is &nbsp; ![Screenshot that is showing the cumulative distribution equation.](../images/awfxpnd2_ZA06051268.gif)
+The equation for the cumulative distribution function is &nbsp; ![Screenshot of the cumulative distribution equation.](../images/awfxpnd2_ZA06051268.gif)
 
 
     

--- a/api/Excel.WorksheetFunction.Expon_Dist.md
+++ b/api/Excel.WorksheetFunction.Expon_Dist.md
@@ -45,7 +45,7 @@ If x < 0, **Expon_Dist** returns the #NUM! error value.
     
 If lambda ≤ 0, **Expon_Dist** returns the #NUM! error value.
     
-The equation for the probability density function is &nbsp; ![Screenshot that is showing the probability density equation.](../images/awfxpnd1_ZA06051267.gif)
+The equation for the probability density function is &nbsp; ![Screenshot of the probability density equation.](../images/awfxpnd1_ZA06051267.gif)
   
 The equation for the cumulative distribution function is &nbsp; ![Screenshot that is showing the cumulative distribution equation.](../images/awfxpnd2_ZA06051268.gif)
 

--- a/api/Excel.WorksheetFunction.FactDouble.md
+++ b/api/Excel.WorksheetFunction.FactDouble.md
@@ -41,9 +41,9 @@ If number is nonnumeric, **FactDouble** returns the #VALUE! error value.
     
 If number is negative, **FactDouble** returns the #NUM! error value.
     
-If number is even: &nbsp; ![Formula](../images/awffdbl1_ZA06051139.gif)
+If number is even: &nbsp; ![Screenshot of the Fact Double equation when the number is even.](../images/awffdbl1_ZA06051139.gif)
 
-If number is odd: &nbsp; ![Formula](../images/awffdbl2_ZA06051140.gif)
+If number is odd: &nbsp; ![Screenshot of the Fact Double equation when the number is odd.](../images/awffdbl2_ZA06051140.gif)
 
 
 

--- a/api/Excel.WorksheetFunction.Forecast.md
+++ b/api/Excel.WorksheetFunction.Forecast.md
@@ -48,7 +48,7 @@ If known_y's and known_x's are empty or contain a different number of data point
     
 If the variance of known_x's equals zero, **Forecast** returns the #DIV/0! error value.
     
-The equation for FORECAST is a+bx, where &nbsp; ![Formula](../images/awfintc1_ZA06051174.gif) &nbsp; and &nbsp; ![Formula](../images/awfintc2_ZA06051175.gif) &nbsp; and where x and y are the sample means AVERAGE(known_x's) and AVERAGE(known_y's). 
+The equation for FORECAST is a+bx, where &nbsp; ![Screenshot showing the formula that defines the a value for the forecast equation.](../images/awfintc1_ZA06051174.gif) &nbsp; and &nbsp; ![Screenshot showing the formula that defines the b value for the forecast equation.](../images/awfintc2_ZA06051175.gif) &nbsp; and where x and y are the sample means AVERAGE(known_x's) and AVERAGE(known_y's). 
     
 
 

--- a/api/Excel.WorksheetFunction.Forecast.md
+++ b/api/Excel.WorksheetFunction.Forecast.md
@@ -48,7 +48,7 @@ If known_y's and known_x's are empty or contain a different number of data point
     
 If the variance of known_x's equals zero, **Forecast** returns the #DIV/0! error value.
     
-The equation for FORECAST is a+bx, where &nbsp; ![Screenshot showing the formula that defines the a value for the forecast equation.](../images/awfintc1_ZA06051174.gif) &nbsp; and &nbsp; ![Screenshot showing the formula that defines the b value for the forecast equation.](../images/awfintc2_ZA06051175.gif) &nbsp; and where x and y are the sample means AVERAGE(known_x's) and AVERAGE(known_y's). 
+The equation for FORECAST is a+bx, where &nbsp; ![Screenshot of a formula that defines a value for the forecast equation.](../images/awfintc1_ZA06051174.gif) &nbsp; and &nbsp; ![Screenshot of the formula that defines the b value for the forecast equation.](../images/awfintc2_ZA06051175.gif) &nbsp; and where x and y are the sample means AVERAGE(known_x's) and AVERAGE(known_y's). 
     
 
 

--- a/api/Excel.WorksheetFunction.GammaDist.md
+++ b/api/Excel.WorksheetFunction.GammaDist.md
@@ -52,15 +52,15 @@ If alpha ≤ 0 or if beta ≤ 0, **GammaDist** returns the #NUM! error value.
     
 The equation for the gamma probability density function is:
 
-> ![Formula](../images/awfgmdi1_ZA06051146.gif)
+> ![Screenshot that shows the gamma probability density equation.](../images/awfgmdi1_ZA06051146.gif)
 
 The standard gamma probability density function is:
 
-> ![Formula](../images/awfgmdi2_ZA06051147.gif)
+> ![Screenshot that shows the standard gamma probability density equation.](../images/awfgmdi2_ZA06051147.gif)
 
 When alpha = 1, **GammaDist** returns the exponential distribution with:
 
-> ![Formula](../images/awfgmdi3_ZA06051148.gif)
+> ![Screenshot that shows the exponential distribution equation.](../images/awfgmdi3_ZA06051148.gif)
 
 For a positive integer n, when alpha = n/2, beta = 2, and cumulative = **True**, **GammaDist** returns (1 - CHIDIST(x)) with n degrees of freedom.
     

--- a/api/Excel.WorksheetFunction.GammaDist.md
+++ b/api/Excel.WorksheetFunction.GammaDist.md
@@ -56,7 +56,7 @@ The equation for the gamma probability density function is:
 
 The standard gamma probability density function is:
 
-> ![Screenshot that shows the standard gamma probability density equation.](../images/awfgmdi2_ZA06051147.gif)
+> ![Screenshot of the standard gamma probability density equation.](../images/awfgmdi2_ZA06051147.gif)
 
 When alpha = 1, **GammaDist** returns the exponential distribution with:
 

--- a/api/Excel.WorksheetFunction.GammaDist.md
+++ b/api/Excel.WorksheetFunction.GammaDist.md
@@ -60,7 +60,7 @@ The standard gamma probability density function is:
 
 When alpha = 1, **GammaDist** returns the exponential distribution with:
 
-> ![Screenshot that shows the exponential distribution equation.](../images/awfgmdi3_ZA06051148.gif)
+> ![Screenshot of the exponential distribution equation](../images/awfgmdi3_ZA06051148.gif)
 
 For a positive integer n, when alpha = n/2, beta = 2, and cumulative = **True**, **GammaDist** returns (1 - CHIDIST(x)) with n degrees of freedom.
     

--- a/api/Excel.WorksheetFunction.GammaDist.md
+++ b/api/Excel.WorksheetFunction.GammaDist.md
@@ -52,7 +52,7 @@ If alpha ≤ 0 or if beta ≤ 0, **GammaDist** returns the #NUM! error value.
     
 The equation for the gamma probability density function is:
 
-> ![Screenshot that shows the gamma probability density equation.](../images/awfgmdi1_ZA06051146.gif)
+> ![Screenshot of the gamma probability density equation.](../images/awfgmdi1_ZA06051146.gif)
 
 The standard gamma probability density function is:
 

--- a/api/Excel.WorksheetFunction.GammaLn.md
+++ b/api/Excel.WorksheetFunction.GammaLn.md
@@ -49,7 +49,7 @@ The number e raised to the GAMMALN(i) power, where i is an integer, returns the 
     
 **GammaLn** is calculated as follows:
 
-> ![Formula](../images/awfgamm1_ZA06051143.gif) &nbsp; where &nbsp; ![Formula](../images/awfgamm2_ZA06051144.gif)
+> ![Screenshot showing the Gamma Ln formula.](../images/awfgamm1_ZA06051143.gif) &nbsp; where &nbsp; ![Screenshot showing the formula for the Gamma X value.](../images/awfgamm2_ZA06051144.gif)
 
 
     

--- a/api/Excel.WorksheetFunction.GammaLn.md
+++ b/api/Excel.WorksheetFunction.GammaLn.md
@@ -49,7 +49,7 @@ The number e raised to the GAMMALN(i) power, where i is an integer, returns the 
     
 **GammaLn** is calculated as follows:
 
-> ![Screenshot showing the Gamma Ln formula.](../images/awfgamm1_ZA06051143.gif) &nbsp; where &nbsp; ![Screenshot showing the formula for the Gamma X value.](../images/awfgamm2_ZA06051144.gif)
+> ![Screenshot of the Gamma Ln formula](../images/awfgamm1_ZA06051143.gif) &nbsp; where &nbsp; ![Screenshot of the formula for the Gamma X value](../images/awfgamm2_ZA06051144.gif)
 
 
     

--- a/api/Excel.WorksheetFunction.GammaLn_Precise.md
+++ b/api/Excel.WorksheetFunction.GammaLn_Precise.md
@@ -45,7 +45,7 @@ The number e raised to the GAMMALN(i) power, where i is an integer, returns the 
     
 **GammaLn** is calculated as follows:
 
-> ![Screenshot of the Gamma Ln formula.](../images/awfgamm1_ZA06051143.gif) &nbsp; where &nbsp; ![Screenshot that shows the formula for the Gamma X value.](../images/awfgamm2_ZA06051144.gif)
+> ![Screenshot of the Gamma Ln formula.](../images/awfgamm1_ZA06051143.gif) &nbsp; where &nbsp; ![Screenshot of the formula for the Gamma X value.](../images/awfgamm2_ZA06051144.gif)
 
 
 

--- a/api/Excel.WorksheetFunction.GammaLn_Precise.md
+++ b/api/Excel.WorksheetFunction.GammaLn_Precise.md
@@ -45,7 +45,7 @@ The number e raised to the GAMMALN(i) power, where i is an integer, returns the 
     
 **GammaLn** is calculated as follows:
 
-> ![Formula](../images/awfgamm1_ZA06051143.gif) &nbsp; where &nbsp; ![Formula](../images/awfgamm2_ZA06051144.gif)
+> ![Screenshot that shows the Gamma Ln formula.](../images/awfgamm1_ZA06051143.gif) &nbsp; where &nbsp; ![Screenshot that shows the formula for the Gamma X value.](../images/awfgamm2_ZA06051144.gif)
 
 
 

--- a/api/Excel.WorksheetFunction.GammaLn_Precise.md
+++ b/api/Excel.WorksheetFunction.GammaLn_Precise.md
@@ -45,7 +45,7 @@ The number e raised to the GAMMALN(i) power, where i is an integer, returns the 
     
 **GammaLn** is calculated as follows:
 
-> ![Screenshot that shows the Gamma Ln formula.](../images/awfgamm1_ZA06051143.gif) &nbsp; where &nbsp; ![Screenshot that shows the formula for the Gamma X value.](../images/awfgamm2_ZA06051144.gif)
+> ![Screenshot of the Gamma Ln formula.](../images/awfgamm1_ZA06051143.gif) &nbsp; where &nbsp; ![Screenshot that shows the formula for the Gamma X value.](../images/awfgamm2_ZA06051144.gif)
 
 
 

--- a/api/Excel.WorksheetFunction.Gamma_Dist.md
+++ b/api/Excel.WorksheetFunction.Gamma_Dist.md
@@ -48,15 +48,15 @@ If alpha ≤ 0 or if beta ≤ 0, **Gamma_Dist** returns the #NUM! error value.
     
 The equation for the gamma probability density function is:
 
-> ![Formula](../images/awfgmdi1_ZA06051146.gif)
+> ![Screenshot showing the gamma probability density equation.](../images/awfgmdi1_ZA06051146.gif)
 
 The standard gamma probability density function is:
 
-> ![Formula](../images/awfgmdi2_ZA06051147.gif)
+> ![Screenshot showing the standard gamma probability density equation.](../images/awfgmdi2_ZA06051147.gif)
 
 When alpha = 1, **Gamma_Dist** returns the exponential distribution with:
 
-> ![Formula](../images/awfgmdi3_ZA06051148.gif)
+> ![Screenshot showing the exponential distribution equation.](../images/awfgmdi3_ZA06051148.gif)
     
 For a positive integer n, when alpha = n/2, beta = 2, and cumulative = **True**, **Gamma_Dist** returns (1 - CHIDIST(x)) with n degrees of freedom.
     

--- a/api/Excel.WorksheetFunction.Gamma_Dist.md
+++ b/api/Excel.WorksheetFunction.Gamma_Dist.md
@@ -56,7 +56,7 @@ The standard gamma probability density function is:
 
 When alpha = 1, **Gamma_Dist** returns the exponential distribution with:
 
-> ![Screenshot showing the exponential distribution equation.](../images/awfgmdi3_ZA06051148.gif)
+> ![Screenshot of the exponential distribution equation.](../images/awfgmdi3_ZA06051148.gif)
     
 For a positive integer n, when alpha = n/2, beta = 2, and cumulative = **True**, **Gamma_Dist** returns (1 - CHIDIST(x)) with n degrees of freedom.
     

--- a/api/Excel.WorksheetFunction.Gamma_Dist.md
+++ b/api/Excel.WorksheetFunction.Gamma_Dist.md
@@ -52,7 +52,7 @@ The equation for the gamma probability density function is:
 
 The standard gamma probability density function is:
 
-> ![Screenshot showing the standard gamma probability density equation.](../images/awfgmdi2_ZA06051147.gif)
+> ![Screenshot of the standard gamma probability density equation.](../images/awfgmdi2_ZA06051147.gif)
 
 When alpha = 1, **Gamma_Dist** returns the exponential distribution with:
 

--- a/api/Excel.WorksheetFunction.Gamma_Dist.md
+++ b/api/Excel.WorksheetFunction.Gamma_Dist.md
@@ -48,7 +48,7 @@ If alpha ≤ 0 or if beta ≤ 0, **Gamma_Dist** returns the #NUM! error value.
     
 The equation for the gamma probability density function is:
 
-> ![Screenshot showing the gamma probability density equation.](../images/awfgmdi1_ZA06051146.gif)
+> ![Screenshot of the gamma probability density equation.](../images/awfgmdi1_ZA06051146.gif)
 
 The standard gamma probability density function is:
 

--- a/api/Excel.WorksheetFunction.ImArgument.md
+++ b/api/Excel.WorksheetFunction.ImArgument.md
@@ -16,7 +16,7 @@ ms.localizationpriority: medium
 
 Returns the argument ![Screenshot of the theta symbol.](../images/theta_ZA06052070.gif) (theta), an angle expressed in radians, such that:
 
-> ![Screenshot which is showing the angle formula.](../images/awfimar1_ZA06051153.gif)
+> ![Screenshot of the angle formula.](../images/awfimar1_ZA06051153.gif)
 
 
 ## Syntax

--- a/api/Excel.WorksheetFunction.ImArgument.md
+++ b/api/Excel.WorksheetFunction.ImArgument.md
@@ -14,7 +14,7 @@ ms.localizationpriority: medium
 
 # WorksheetFunction.ImArgument method (Excel)
 
-Returns the argument ![Screenshot showing the theta symbol.](../images/theta_ZA06052070.gif) (theta), an angle expressed in radians, such that:
+Returns the argument ![Screenshot of the theta symbol.](../images/theta_ZA06052070.gif) (theta), an angle expressed in radians, such that:
 
 > ![Screenshot which is showing the angle formula.](../images/awfimar1_ZA06051153.gif)
 

--- a/api/Excel.WorksheetFunction.ImArgument.md
+++ b/api/Excel.WorksheetFunction.ImArgument.md
@@ -43,7 +43,7 @@ Use the **[Complex](excel.worksheetfunction.complex.md)** method to convert real
     
 **ImArgument** is calculated as follows:
 
-> ![Screenshot showing the Im Argument formula.](../images/awfimar2_ZA06051154.gif) &nbsp; where &nbsp; ![Screenshot showing the theta value formula.](../images/awfimar3_ZA06051155.gif) &nbsp; and z = x + yi
+> ![Screenshot of Im Argument formula.](../images/awfimar2_ZA06051154.gif) &nbsp; where &nbsp; ![Screenshot of the theta value formula.](../images/awfimar3_ZA06051155.gif) &nbsp; and z = x + yi
     
 
 

--- a/api/Excel.WorksheetFunction.ImArgument.md
+++ b/api/Excel.WorksheetFunction.ImArgument.md
@@ -14,9 +14,9 @@ ms.localizationpriority: medium
 
 # WorksheetFunction.ImArgument method (Excel)
 
-Returns the argument ![Formula](../images/theta_ZA06052070.gif) (theta), an angle expressed in radians, such that:
+Returns the argument ![Screenshot showing the theta symbol.](../images/theta_ZA06052070.gif) (theta), an angle expressed in radians, such that:
 
-> ![Formula](../images/awfimar1_ZA06051153.gif)
+> ![Screenshot which is showing the angle formula.](../images/awfimar1_ZA06051153.gif)
 
 
 ## Syntax
@@ -43,7 +43,7 @@ Use the **[Complex](excel.worksheetfunction.complex.md)** method to convert real
     
 **ImArgument** is calculated as follows:
 
-> ![Formula](../images/awfimar2_ZA06051154.gif) &nbsp; where &nbsp; ![Formula](../images/awfimar3_ZA06051155.gif) &nbsp; and z = x + yi
+> ![Screenshot showing the Im Argument formula.](../images/awfimar2_ZA06051154.gif) &nbsp; where &nbsp; ![Screenshot showing the theta value formula.](../images/awfimar3_ZA06051155.gif) &nbsp; and z = x + yi
     
 
 

--- a/api/Excel.WorksheetFunction.ImLn.md
+++ b/api/Excel.WorksheetFunction.ImLn.md
@@ -39,7 +39,7 @@ _expression_ A variable that represents a **[WorksheetFunction](Excel.WorksheetF
 
 Use the **[Complex](excel.worksheetfunction.complex.md)** method to convert real and imaginary coefficients into a complex number.
     
-The natural logarithm of a complex number is &nbsp; ![Screenshot of the natural logarithm of a complex number formula.](../images/awfimln_ZA06051162.gif) &nbsp; where &nbsp; ![Screenshot that shows the theta value formula.](../images/awfimar3_ZA06051155.gif)
+The natural logarithm of a complex number is &nbsp; ![Screenshot of the natural logarithm of a complex number formula.](../images/awfimln_ZA06051162.gif) &nbsp; where &nbsp; ![Screenshot of the theta value formula.](../images/awfimar3_ZA06051155.gif)
 
 
     

--- a/api/Excel.WorksheetFunction.ImLn.md
+++ b/api/Excel.WorksheetFunction.ImLn.md
@@ -39,7 +39,7 @@ _expression_ A variable that represents a **[WorksheetFunction](Excel.WorksheetF
 
 Use the **[Complex](excel.worksheetfunction.complex.md)** method to convert real and imaginary coefficients into a complex number.
     
-The natural logarithm of a complex number is &nbsp; ![Screenshot showing the natural logarithm of a complex number formula.](../images/awfimln_ZA06051162.gif) &nbsp; where &nbsp; ![Screenshot that shows the theta value formula.](../images/awfimar3_ZA06051155.gif)
+The natural logarithm of a complex number is &nbsp; ![Screenshot of the natural logarithm of a complex number formula.](../images/awfimln_ZA06051162.gif) &nbsp; where &nbsp; ![Screenshot that shows the theta value formula.](../images/awfimar3_ZA06051155.gif)
 
 
     

--- a/api/Excel.WorksheetFunction.ImLn.md
+++ b/api/Excel.WorksheetFunction.ImLn.md
@@ -39,7 +39,7 @@ _expression_ A variable that represents a **[WorksheetFunction](Excel.WorksheetF
 
 Use the **[Complex](excel.worksheetfunction.complex.md)** method to convert real and imaginary coefficients into a complex number.
     
-The natural logarithm of a complex number is &nbsp; ![Formula](../images/awfimln_ZA06051162.gif) &nbsp; where &nbsp; ![Formula](../images/awfimar3_ZA06051155.gif)
+The natural logarithm of a complex number is &nbsp; ![Screenshot showing the natural logarithm of a complex number formula.](../images/awfimln_ZA06051162.gif) &nbsp; where &nbsp; ![Screenshot that shows the theta value formula.](../images/awfimar3_ZA06051155.gif)
 
 
     

--- a/api/Excel.worksheetfunction.forecast_linear.md
+++ b/api/Excel.worksheetfunction.forecast_linear.md
@@ -44,7 +44,7 @@ If _known_y_ and _known_x_ parameters are empty or contain a different number of
     
 If the variance of _known_x_ parameters equals zero, **Forecast_Linear** returns the #DIV/0! error value.
     
-The equation for **Forecast_Linear** is a+bx, where &nbsp; ![Screenshot showing the formula that defines the a value for the forecast linear equation.](../images/awfintc1_ZA06051174.gif) &nbsp; and &nbsp; ![Screenshot showing the formula that defines the b value for the forecast linear equation.](../images/awfintc2_ZA06051175.gif) &nbsp; and where x and y are the sample means AVERAGE(all _known_x_) and AVERAGE(all _known_y_).
+The equation for **Forecast_Linear** is a+bx, where &nbsp; ![Screenshot of the formula that defines the a value for the forecast linear equation.](../images/awfintc1_ZA06051174.gif) &nbsp; and &nbsp; ![Screenshot of the formula that defines the b value for the forecast linear equation.](../images/awfintc2_ZA06051175.gif) &nbsp; and where x and y are the sample means AVERAGE(all _known_x_) and AVERAGE(all _known_y_).
     
 
 ## Example

--- a/api/Excel.worksheetfunction.forecast_linear.md
+++ b/api/Excel.worksheetfunction.forecast_linear.md
@@ -44,7 +44,7 @@ If _known_y_ and _known_x_ parameters are empty or contain a different number of
     
 If the variance of _known_x_ parameters equals zero, **Forecast_Linear** returns the #DIV/0! error value.
     
-The equation for **Forecast_Linear** is a+bx, where &nbsp; ![Formula](../images/awfintc1_ZA06051174.gif) &nbsp; and &nbsp; ![Formula](../images/awfintc2_ZA06051175.gif) &nbsp; and where x and y are the sample means AVERAGE(all _known_x_) and AVERAGE(all _known_y_).
+The equation for **Forecast_Linear** is a+bx, where &nbsp; ![Screenshot showing the formula that defines the a value for the forecast linear equation.](../images/awfintc1_ZA06051174.gif) &nbsp; and &nbsp; ![Screenshot showing the formula that defines the b value for the forecast linear equation.](../images/awfintc2_ZA06051175.gif) &nbsp; and where x and y are the sample means AVERAGE(all _known_x_) and AVERAGE(all _known_y_).
     
 
 ## Example


### PR DESCRIPTION
Fixed: 

- docs-link-absolute errors (absolute links replaced with relative links)
- image-alt-text-duplicated errors (duplicate alt text descriptions within an article)
- preserve-view-not-set errors (&preserve-view=true was not set on versioned links)

This PR fixes 55 issues across 30 files and is part of ongoing Validation cleanup efforts. No other content has been edited or added.