### PR TITLE
Validation: Absolute links, duplicate image alt text, and preserve view error fixes.

### DIFF
--- a/api/Excel.WorksheetFunction.ImPower.md
+++ b/api/Excel.WorksheetFunction.ImPower.md
@@ -46,19 +46,19 @@ Number can be an integer, fractional, or negative.
     
 A complex number raised to a power is calculated as follows:
 
-> ![Formula](../images/awfimpw1_ZA06051164.gif) 
+> ![Screenshot that shows the complex number formula.](../images/awfimpw1_ZA06051164.gif) 
 
 where: 
 
-> ![Formula](../images/awfimpw2_ZA06051165.gif)
+> ![Second screenshot that shows the complex number formula.](../images/awfimpw2_ZA06051165.gif)
 
 and: 
 
-> ![Formula](../images/awfimpw3_ZA06051166.gif)
+> ![Third screenshot that shows the complex number formula.](../images/awfimpw3_ZA06051166.gif)
 
 and: 
 
-> ![Formula](../images/awfimar3_ZA06051155.gif)
+> ![Fourth screenshot that shows the complex number formula.](../images/awfimar3_ZA06051155.gif)
 
 
     

--- a/api/Excel.WorksheetFunction.ImPower.md
+++ b/api/Excel.WorksheetFunction.ImPower.md
@@ -46,19 +46,19 @@ Number can be an integer, fractional, or negative.
     
 A complex number raised to a power is calculated as follows:
 
-> ![Screenshot that shows the complex number formula.](../images/awfimpw1_ZA06051164.gif) 
+> ![Screenshot of the complex number formula.](../images/awfimpw1_ZA06051164.gif) 
 
 where: 
 
-> ![Second screenshot that shows the complex number formula.](../images/awfimpw2_ZA06051165.gif)
+> ![Second screenshot of the complex number formula.](../images/awfimpw2_ZA06051165.gif)
 
 and: 
 
-> ![Third screenshot that shows the complex number formula.](../images/awfimpw3_ZA06051166.gif)
+> ![Third screenshot of the complex number formula.](../images/awfimpw3_ZA06051166.gif)
 
 and: 
 
-> ![Fourth screenshot that shows the complex number formula.](../images/awfimar3_ZA06051155.gif)
+> ![Fourth screenshot of the complex number formula.](../images/awfimar3_ZA06051155.gif)
 
 
     

--- a/api/Excel.WorksheetFunction.ImSqrt.md
+++ b/api/Excel.WorksheetFunction.ImSqrt.md
@@ -41,19 +41,19 @@ Use the **[Complex](excel.worksheetfunction.complex.md)** method to convert real
     
 The square root of a complex number is:
 
-> ![Screenshot that shows the square root of a complex number formula.](../images/awfimsq1_ZA06051168.gif)
+> ![Screenshot of the square root of a complex number formula.](../images/awfimsq1_ZA06051168.gif)
 
 where: 
 
-> ![Second screenshot that shows the square root of a complex number formula.](../images/awfimsq2_ZA06051169.gif)
+> ![Second screenshot of the square root of a complex number formula.](../images/awfimsq2_ZA06051169.gif)
 
 and: 
 
-> ![Third screenshot that shows the square root of a complex number formula.](../images/awfimsq3_ZA06051170.gif)
+> ![Third screenshot of the square root of a complex number formula.](../images/awfimsq3_ZA06051170.gif)
 
 and: 
 
-> ![Fourth screenshot that shows the square root of a complex number formula.](../images/awfimar3_ZA06051155.gif)
+> ![Fourth screenshot of the square root of a complex number formula.](../images/awfimar3_ZA06051155.gif)
 
 
     

--- a/api/Excel.WorksheetFunction.ImSqrt.md
+++ b/api/Excel.WorksheetFunction.ImSqrt.md
@@ -41,19 +41,19 @@ Use the **[Complex](excel.worksheetfunction.complex.md)** method to convert real
     
 The square root of a complex number is:
 
-> ![Formula](../images/awfimsq1_ZA06051168.gif)
+> ![Screenshot that shows the square root of a complex number formula.](../images/awfimsq1_ZA06051168.gif)
 
 where: 
 
-> ![Formula](../images/awfimsq2_ZA06051169.gif)
+> ![Second screenshot that shows the square root of a complex number formula.](../images/awfimsq2_ZA06051169.gif)
 
 and: 
 
-> ![Formula](../images/awfimsq3_ZA06051170.gif)
+> ![Third screenshot that shows the square root of a complex number formula.](../images/awfimsq3_ZA06051170.gif)
 
 and: 
 
-> ![Formula](../images/awfimar3_ZA06051155.gif)
+> ![Fourth screenshot that shows the square root of a complex number formula.](../images/awfimar3_ZA06051155.gif)
 
 
     

--- a/api/Visio.Documents.OpenEx.md
+++ b/api/Visio.Documents.OpenEx.md
@@ -68,7 +68,7 @@ If **visOpenHidden** is specified, the file opens in a hidden window.
 
 If **visOpenNoWorkspace** is specified, the file opens with no workspace information.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this method maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this method maps to the following types:
 
 - **Microsoft.Office.Interop.Visio.IVDocuments.OpenEx(string, short)**
     

--- a/api/Visio.InvisibleApp.AddonPaths.md
+++ b/api/Visio.InvisibleApp.AddonPaths.md
@@ -39,7 +39,7 @@ The string passed to and received from the **AddonPaths** property is the same s
 
 When Visio looks for third-party and user add-ons, it looks in all paths named in the **AddonPaths** property, as well as at the paths of any add-ons installed at setup, and all the subfolders of those paths. If you pass the **AddonPaths** property to the **EnumDirectories** method, it returns a complete list of fully qualified paths in the folders passed in.
 
-Starting with Microsoft Office Visio 2003, instead of specifying file paths to your Visio add-ons, you can publish your add-ons by using a Microsoft Windows Installer package. By doing so, you can take advantage of Microsoft Office features such as language switching, installation on demand, and repair. For more information about using a Windows Installer package to publish your add-ons, see [Windows Installer](https://docs.microsoft.com/windows/desktop/msi/windows-installer-portal).
+Starting with Microsoft Office Visio 2003, instead of specifying file paths to your Visio add-ons, you can publish your add-ons by using a Microsoft Windows Installer package. By doing so, you can take advantage of Microsoft Office features such as language switching, installation on demand, and repair. For more information about using a Windows Installer package to publish your add-ons, see [Windows Installer](/windows/desktop/msi/windows-installer-portal).
 
 
 > [!WARNING] 

--- a/api/Visio.InvisibleApp.FormatResultEx.md
+++ b/api/Visio.InvisibleApp.FormatResultEx.md
@@ -75,7 +75,7 @@ _Format_ is a string that specifies a template or picture of the string produced
 
 When _UnitsIn_ is **visDate**, _Format_ should be one of the custom Microsoft Visio expanded-form date/time formats, which are of the form "{{_date/time format picture_}}". You can view these formats in the **Custom Format** box in the **Data Format** dialog box in Visio (select a shape, and then, on the **Insert** tab, choose **Field**. In the **Category** list, choose **Date/Time**, and then choose **Data Format**).
 
-The _LangID_ argument is optional. If you don't specify a value, Visio uses the current system language. If you pass a value, the _LangID_ argument should be one of the standard IDs used by Windows to encode different language versions. For example, 1033 is the language ID for English (United States). To see a list of possible language IDs, see [Language Identifier Constants and Strings](https://docs.microsoft.com/windows/desktop/intl/language-identifier-constants-and-strings).
+The _LangID_ argument is optional. If you don't specify a value, Visio uses the current system language. If you pass a value, the _LangID_ argument should be one of the standard IDs used by Windows to encode different language versions. For example, 1033 is the language ID for English (United States). To see a list of possible language IDs, see [Language Identifier Constants and Strings](/windows/desktop/intl/language-identifier-constants-and-strings).
 
 The _CalendarID_ argument should be one of the following values, which are declared in **[VisCellVals](visio.viscellvals.md)** in the Visio type library. The default value is the Western calendar, **visCalWestern**.
 

--- a/api/Visio.InvisibleApp.InvokeHelp.md
+++ b/api/Visio.InvisibleApp.InvokeHelp.md
@@ -41,7 +41,7 @@ Nothing
 
 Using the **InvokeHelp** method, you can create a custom Help system that is integrated with the Visio Help system. To enable your custom Help to appear in the same MSO Help window as Visio Help, don't specify a window definition in the _bstrHelpFileName_ argument.
 
-The arguments passed to the **InvokeHelp** method correspond to those described in the HTML Help API. For a list of command values, see the [HTML Help API Reference](https://docs.microsoft.com/previous-versions/windows/desktop/legacy/ms670068(v=vs.85)). Microsoft Visual Basic programmers can use the numeric equivalent of the C++ constants defined in the HTML Help API header files.
+The arguments passed to the **InvokeHelp** method correspond to those described in the HTML Help API. For a list of command values, see the [HTML Help API Reference](/previous-versions/windows/desktop/legacy/ms670068(v=vs.85)). Microsoft Visual Basic programmers can use the numeric equivalent of the C++ constants defined in the HTML Help API header files.
 
 For example, use the following code to display the Visio Help window.
 

--- a/api/Visio.InvisibleApp.Language.md
+++ b/api/Visio.InvisibleApp.Language.md
@@ -33,6 +33,6 @@ Long
 
 The **Language** property returns the language ID recorded in the object's VERSIONINFO resource. The IDs returned are the standard IDs used by Windows to encode different language versions. For example, the **Language** property returns &H0409 for the U.S. English version of Visio. 
 
-For more information, see [Version information](https://docs.microsoft.com/windows/desktop/menurc/version-information).
+For more information, see [Version information](/windows/desktop/menurc/version-information).
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Visio.InvisibleApp.LanguageHelp.md
+++ b/api/Visio.InvisibleApp.LanguageHelp.md
@@ -33,6 +33,6 @@ Long
 
 The **LanguageHelp** property returns the language ID of the Help recorded in the object's VERSIONINFO resource. The IDs returned are the standard IDs used by Windows to encode different language versions. For example, the **LanguageHelp** property returns &H0409 for the U.S. English version of Visio. 
 
-For more information, see [Version information](https://docs.microsoft.com/windows/desktop/menurc/version-information).
+For more information, see [Version information](/windows/desktop/menurc/version-information).
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Visio.Masters.Item.md
+++ b/api/Visio.Masters.Item.md
@@ -76,7 +76,7 @@ For more information about passing ID strings to the **Item** property, see the 
 
 As a developer, you can use universal names in a program when you don't want to change a name each time a solution is localized. Use the **Item** property to access an object in the **Masters**, **Pages**, **Shapes**, **Styles**, **Layers**, or **MasterShortcuts** collection by using its local name. Use the **ItemU** property to access an object from one of these collections by using the object's universal name.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this property maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this property maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVMasters.this[object]**

--- a/api/Visio.Masters.md
+++ b/api/Visio.Masters.md
@@ -23,7 +23,7 @@ To retrieve a **Masters** collection, use the **[Masters](visio.document.masters
 
 The default property of a **Masters** collection is **Item**.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this collection maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this collection maps to the following types:
 
 - **Microsoft.Office.Interop.Visio.IVMasters**
     

--- a/api/Visio.Page.Application.md
+++ b/api/Visio.Page.Application.md
@@ -31,7 +31,7 @@ _expression_ A variable that represents a **[Page](Visio.Page.md)** object.
 
 ## Remarks
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this property maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this property maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVPage.Application**

--- a/api/Visio.Page.Document.md
+++ b/api/Visio.Page.Document.md
@@ -31,7 +31,7 @@ Document
 
 ## Remarks
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this property maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this property maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVPage.Document**

--- a/api/Visio.Page.Drop.md
+++ b/api/Visio.Page.Drop.md
@@ -47,7 +47,7 @@ To add a shape to a group or on a drawing page, apply the **Drop** method to a *
 
 If ObjectToDrop is a **Master**, the pin of the master is dropped at the specified coordinates. A master's pin is often, but not necessarily, at its center of rotation.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this method maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this method maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVPage.Drop(object, double, double)**

--- a/api/Visio.Page.Export.md
+++ b/api/Visio.Page.Export.md
@@ -47,7 +47,7 @@ If the specified file already exists, Visio replaces it without prompting the us
 
 Starting with Visio 2010, you can use various properties and methods of the **[ApplicationSettings](Visio.ApplicationSettings.md)** object that relate to raster images to configure settings for export to .bmp, .gif, .jpg, .png, and .tif file types.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this method maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this method maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVPage.Export(string)**

--- a/api/Visio.Page.ResizeToFitContents.md
+++ b/api/Visio.Page.ResizeToFitContents.md
@@ -35,7 +35,7 @@ After the page is resized, the page height and width and the PinX and PinY value
 
 Calling the **ResizeToFitContents** method is the equivalent of selecting **Let Visio expand the page as needed** on the **Page Size** tab in the **Page Setup** dialog box (on the **Design** tab, click **Size**, and then click **More Page Sizes**).
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this method maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this method maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVPage.ResizeToFitContents()**

--- a/api/Visio.Page.Shapes.md
+++ b/api/Visio.Page.Shapes.md
@@ -31,7 +31,7 @@ Shapes
 
 ## Remarks
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this property maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this property maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVPage.Shapes**

--- a/api/Visio.Pages.Item.md
+++ b/api/Visio.Pages.Item.md
@@ -58,7 +58,7 @@ For more information about passing ID strings to the **Item** property, see the 
 
 As a developer, you can use universal names in a program when you don't want to change a name each time a solution is localized. Use the **Item** property to access an object in the **Masters**, **Pages**, **Shapes**, **Styles**, **Layers**, or **MasterShortcuts** collection by using its local name. Use the **ItemU** property to access an object from one of these collections by using the object's universal name.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this property maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this property maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVPages.this[object]**

--- a/api/Visio.Shape.Application.md
+++ b/api/Visio.Shape.Application.md
@@ -31,7 +31,7 @@ _expression_ A variable that represents a **[Shape](Visio.Shape.md)** object.
 
 ## Remarks
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this property maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this property maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVShape.Application**

--- a/api/Visio.Shape.AutoConnect.md
+++ b/api/Visio.Shape.AutoConnect.md
@@ -57,7 +57,7 @@ For the PlacementDir parameter, pass a value from the **VisAutoConnectDir** enum
 |visAutoConnectDirRight|4|Connect to the right|
 |visAutoConnectDirUp|1|Connect up.|
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this method maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this method maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVShape.AutoConnect(Microsoft.Office.Interop.Visio.Shape, Microsoft.Office.Interop.Visio.VisAutoConnectDir, object)**

--- a/api/Visio.Shape.BeforeShapeDelete.md
+++ b/api/Visio.Shape.BeforeShapeDelete.md
@@ -56,7 +56,7 @@ To find an event code for the event that you want to create, see [Event codes](.
 
 For performance considerations, the **Document** object's event set does not include the **BeforeShapeDelete** event. To sink the **BeforeShapeDelete** event from a **Document** object (and from the **[ThisDocument](../visio/Concepts/about-the-thisdocument-object-visio.md)** object in a VBA project), you must use the **AddAdvise** method.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this event maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this event maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.EShape_BeforeShapeDeleteEventHandler** (the **BeforeShapeDelete** delegate.)

--- a/api/Visio.Shape.CellsSRC.md
+++ b/api/Visio.Shape.CellsSRC.md
@@ -54,7 +54,7 @@ The **CellsSRC** property is typically used to iterate through the cells in a se
 Set vsoCell = Cells("PinX")
 ```
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this property maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this property maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVShape.get_CellsSRC**

--- a/api/Visio.Shape.Characters.md
+++ b/api/Visio.Shape.Characters.md
@@ -31,7 +31,7 @@ Characters
 
 ## Remarks
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this property maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this property maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVShape.Characters**

--- a/api/Visio.Shape.Delete.md
+++ b/api/Visio.Shape.Delete.md
@@ -31,7 +31,7 @@ Nothing
 
 ## Remarks
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this method maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this method maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVShape.Delete()**

--- a/api/Visio.Shape.ID.md
+++ b/api/Visio.Shape.ID.md
@@ -37,7 +37,7 @@ If a shape, page, master, or style is deleted, future objects in the same scope 
 
 For **Shape** objects, you can use the **ID** property with methods such as **GetResults** and **SetResults** to get or set many cell values at once, possibly cells in many different shapes. To do this, you must pass shape IDs to the methods. If you create shapes by using the **DropMany** method, the method returns the IDs of the shapes it creates to your program.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this property maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this property maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVShape.ID**

--- a/api/Visio.Shape.Name.md
+++ b/api/Visio.Shape.Name.md
@@ -41,7 +41,7 @@ A cell has both a local name and a universal name. The local name differs depend
 
 As a developer, you can use universal names in a program when you don't want to change a name each time a solution is localized. Use the **Name** property to get or set a **Hyperlink**, **Layer**, **Master**, **MasterShortcut**, **Page**, **Shape**, **Style**, or **Row** object's local name. Use the **NameU** property to get or set its universal name.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this property maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this property maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVShape.Name**

--- a/api/Visio.Shape.Text.md
+++ b/api/Visio.Shape.Text.md
@@ -46,7 +46,7 @@ If the shape is a group, the text returned is dependent on the value of the IsTe
 
 Objects from other applications and guides don't have a **Text** property.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this property maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this property maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVShape.Text**

--- a/api/Visio.Shapes.ItemFromID.md
+++ b/api/Visio.Shapes.ItemFromID.md
@@ -45,7 +45,7 @@ The ID of a **Font** object corresponds to the number stored in the Font cell of
 
 The ID of an **Event** object uniquely identifies an event in its **EventList** collection for the life of the collection.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this property maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this property maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVShapes.get_ItemFromID**

--- a/api/Visio.Shapes.md
+++ b/api/Visio.Shapes.md
@@ -25,7 +25,7 @@ The default property of a **Shapes** collection is **Item**.
 
 The order of items in a **Shapes** collection corresponds to the stacking (drawing) order of the shapes.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this collection maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this collection maps to the following types:
 
 - **Microsoft.Office.Interop.Visio.IVShapes**
     

--- a/api/Visio.Window.Activate.md
+++ b/api/Visio.Window.Activate.md
@@ -33,7 +33,7 @@ Nothing
 
 Microsoft Visio can have more than one window open at a time; however, only one window is active. Activating a window can change the objects returned by the **ActiveWindow**, **ActivePage**, and **ActiveDocument** properties.
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this method maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this method maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVWindow.Activate()**

--- a/api/Visio.Window.DeselectAll.md
+++ b/api/Visio.Window.DeselectAll.md
@@ -31,7 +31,7 @@ Nothing
 
 ## Remarks
 
-If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](https://docs.microsoft.com/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019) reference, this method maps to the following types:
+If your Visual Studio solution includes the [Microsoft.Office.Interop.Visio](/visualstudio/vsto/office-primary-interop-assemblies?view=vs-2019&preserve-view=true) reference, this method maps to the following types:
 
 
 - **Microsoft.Office.Interop.Visio.IVWindow.DeselectAll()**


### PR DESCRIPTION
Fixed: 

- docs-link-absolute errors (absolute links replaced with relative links)
- image-alt-text-duplicated errors (duplicate alt text descriptions within an article)
- preserve-view-not-set errors (&preserve-view=true was not set on versioned links)

This PR fixes 61 issues across 30 files and is part of ongoing Validation cleanup efforts. No other content has been edited or added.