### PR TITLE
Validation: Absolute links error fixes.

### DIFF
--- a/Library-Reference/Concepts/customize-the-office-fluent-ribbon-by-using-a-managed-com-add-in.md
+++ b/Library-Reference/Concepts/customize-the-office-fluent-ribbon-by-using-a-managed-com-add-in.md
@@ -220,6 +220,6 @@ Choose the **My Tab** tab, and then choose **Insert Company Name** to insert the
 
 - [Overview of the Office Fluent ribbon](overview-of-the-office-fluent-ribbon.md)
 - [Customize the Office Fluent ribbon by using an Open XML formats file](customize-the-office-fluent-ribbon-by-using-an-open-xml-formats-file.md)
-- [Customize the Office Fluent ribbon by using a Visual Basic COM add-in](https://docs.microsoft.com/previous-versions/office/developer/office-2010/ff863131(v=office.14))
+- [Customize the Office Fluent ribbon by using a Visual Basic COM add-in](/previous-versions/office/developer/office-2010/ff863131(v=office.14))
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/Library-Reference/Concepts/customize-the-office-fluent-ribbon-by-using-an-open-xml-formats-file.md
+++ b/Library-Reference/Concepts/customize-the-office-fluent-ribbon-by-using-an-open-xml-formats-file.md
@@ -86,6 +86,6 @@ The code example in this topic shows how to add custom components to the ribbon 
 
 - [Overview of the Office Fluent ribbon](overview-of-the-office-fluent-ribbon.md)
 - [Customize the Office Fluent ribbon by using a managed COM add-in](customize-the-office-fluent-ribbon-by-using-a-managed-com-add-in.md)
-- [Customize the Office Fluent ribbon by using a Visual Basic COM add-in](https://docs.microsoft.com/previous-versions/office/developer/office-2010/ff863131(v=office.14))
+- [Customize the Office Fluent ribbon by using a Visual Basic COM add-in](/previous-versions/office/developer/office-2010/ff863131(v=office.14))
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/Library-Reference/Concepts/overview-of-the-office-fluent-ribbon.md
+++ b/Library-Reference/Concepts/overview-of-the-office-fluent-ribbon.md
@@ -163,6 +163,6 @@ The ribbon gives users a flexible way to work with Office applications. You use 
 
 - [Customize the Office Fluent ribbon by using a managed COM add-in](customize-the-office-fluent-ribbon-by-using-a-managed-com-add-in.md)
 - [Customize the Office Fluent ribbon by using an Open XML formats file](customize-the-office-fluent-ribbon-by-using-an-open-xml-formats-file.md)
-- [Customize the Office Fluent ribbon by using a Visual Basic COM add-in](https://docs.microsoft.com/previous-versions/office/developer/office-2010/ff863131(v=office.14))
+- [Customize the Office Fluent ribbon by using a Visual Basic COM add-in](/previous-versions/office/developer/office-2010/ff863131(v=office.14))
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/visio/Concepts/about-security-settings-and-running-code-in-visio.md
+++ b/visio/Concepts/about-security-settings-and-running-code-in-visio.md
@@ -29,7 +29,7 @@ For more information about good security design practices and technologies, sear
 
 ## Additional Visio resources
 
-- To learn more about Visio add-ons and COM add-ins, see [Overview of Add-ons and COM Add-ins in Visio 2007](https://docs.microsoft.com/previous-versions/office/developer/office-2007/bb851468(v=office.12)).
-- To learn more about the RUNADDON function and the **AddonName** property, see [Changes in the RUNADDON Function and the AddOnName Property for Visio 2002](https://docs.microsoft.com/previous-versions/office/developer/office-xp/aa140368(v=office.10)?redirectedfrom=MSDN).
+- To learn more about Visio add-ons and COM add-ins, see [Overview of Add-ons and COM Add-ins in Visio 2007](/previous-versions/office/developer/office-2007/bb851468(v=office.12)).
+- To learn more about the RUNADDON function and the **AddonName** property, see [Changes in the RUNADDON Function and the AddOnName Property for Visio 2002](/previous-versions/office/developer/office-xp/aa140368(v=office.10)?redirectedfrom=MSDN).
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]


### PR DESCRIPTION
Fixed: 

- docs-link-absolute errors (absolute links replaced with relative links)

This PR fixes 5 issues across 4 files and is part of ongoing Validation cleanup efforts. No other content has been edited or added.