### PR TITLE
The example throws a "Type Mismatch" error

### DIFF
--- a/Language/Reference/User-Interface-Help/split-function.md
+++ b/Language/Reference/User-Interface-Help/split-function.md
@@ -44,8 +44,8 @@ This example shows how to use the **Split** function.
 
 ```vb
 Dim strFull As String
-Dim arrSplitStrings1() As Variant
-Dim arrSplitStrings2() As Variant
+Dim arrSplitStrings1() As String
+Dim arrSplitStrings2() As String
 Dim strSingleString1 As String
 Dim strSingleString2 As String
 Dim strSingleString3 As String


### PR DESCRIPTION
Assigning a Variant array with Split throws a "Type Mismatch" error.
The variables assigned by Split must be String arrays.