### PR TITLE
Add PowerPoint partial documents support documentation

### DIFF
--- a/api/PowerPoint.CustomLayouts.Paste.md
+++ b/api/PowerPoint.CustomLayouts.Paste.md
@@ -39,7 +39,7 @@ CustomLayout
 
 ## Remarks
 
-If the source content is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+If the source content is not fully downloaded, this method fails, and an error occurs. For more information about partial documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
 
 
 ## See also

--- a/api/PowerPoint.CustomLayouts.Paste.md
+++ b/api/PowerPoint.CustomLayouts.Paste.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.CustomLayouts.Paste
 ms.assetid: d4fcd2db-3d6b-0c59-6ea3-f9aadf90ed04
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.CustomLayouts.Paste.md
+++ b/api/PowerPoint.CustomLayouts.Paste.md
@@ -37,9 +37,16 @@ _expression_ A variable that represents a [CustomLayouts](PowerPoint.CustomLayou
 CustomLayout
 
 
+## Remarks
+
+If the source content is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 ## See also
 
 
 [CustomLayouts Object](PowerPoint.CustomLayouts.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.MediaFormat.Resample.md
+++ b/api/PowerPoint.MediaFormat.Resample.md
@@ -46,10 +46,14 @@ Nothing
 
  **Resample** ignores the values of parameters that are not applicable to the media.
 
+If the media content is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 
 ## See also
 
 
 [MediaFormat Object](PowerPoint.MediaFormat.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.MediaFormat.Resample.md
+++ b/api/PowerPoint.MediaFormat.Resample.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.MediaFormat.Resample
 ms.assetid: d1bb8b41-4640-c57c-83bc-3263376b425e
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.MediaFormat.ResampleFromProfile.md
+++ b/api/PowerPoint.MediaFormat.ResampleFromProfile.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.MediaFormat.ResampleFromProfile
 ms.assetid: f2d0ed29-82f1-e3f3-a4d9-e00a911176b3
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.MediaFormat.ResampleFromProfile.md
+++ b/api/PowerPoint.MediaFormat.ResampleFromProfile.md
@@ -50,9 +50,14 @@ profile must be one of the following **PpResampleMediaProfile** constants.
 |**ppResampleMediaProfileSmaller**|3|Smaller profile|
 |**ppResampleMediaProfileSmallest**|4|Smallest profile|
 
+If the media content is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 ## See also
 
 
 [MediaFormat Object](PowerPoint.MediaFormat.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Presentation.Export.md
+++ b/api/PowerPoint.Presentation.Export.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Presentation.Export
 ms.assetid: e114d86d-0400-35d3-fc89-d93748993874
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Presentation.Export.md
+++ b/api/PowerPoint.Presentation.Export.md
@@ -41,6 +41,8 @@ Exporting a presentation doesn't set the **[Saved](PowerPoint.Presentation.Saved
 
 PowerPoint uses the specified graphics filter to save each individual slide in the presentation. The names of the slides exported and saved to disk are determined by PowerPoint. They're typically saved by using names such as Slide1.wmf, Slide2.wmf. The path of the saved files is specified in the Path argument.
 
+If the presentation is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 
 ## Example
 
@@ -61,5 +63,7 @@ End With
 
 
 [Presentation Object](PowerPoint.Presentation.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Presentation.ExportAsFixedFormat.md
+++ b/api/PowerPoint.Presentation.ExportAsFixedFormat.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Presentation.ExportAsFixedFormat
 ms.assetid: bad3c9cb-49d7-2fdd-5110-9c1ed6491b08
-ms.date: 07/27/2022
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 
@@ -140,5 +140,7 @@ End Sub
 
 ### See also
 [Manage sensitivity labels in Office apps](/microsoft-365/compliance/sensitivity-labels-office-apps?view=o365-worldwide#pdf-support&preserve-view=true)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Presentation.ExportAsFixedFormat.md
+++ b/api/PowerPoint.Presentation.ExportAsFixedFormat.md
@@ -124,6 +124,8 @@ The _KeepIRMSettings_ parameter behaves specially for PDF. It controls the reten
 
 Due to the interaction of partner add-ins creating PDFs in Office with encryption, Office will default the _KeepIRMSettings_ flag to **FALSE** until [second RMID (93406)](https://www.microsoft.com/microsoft-365/roadmap?filters=&searchterms=93406) releases. For complete details how to adapt to this change, read the [Changes in Export to PDF with sensitivity labeling and encryption in Office Add-ins](https://devblogs.microsoft.com/microsoft365dev/changes-in-export-to-pdf-with-sensitivity-labelling-and-encryption-in-office-add-ins/) blog post by Chris Dietsch.
 
+If the presentation is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 ## Example
 
 The following example shows how to use the **ExportAsFixedFormat** method to export the active presentation as a .pdf file named _test.pdf_ to the user's Documents folder.

--- a/api/PowerPoint.Presentation.IsFullyDownloaded.md
+++ b/api/PowerPoint.Presentation.IsFullyDownloaded.md
@@ -24,11 +24,11 @@ _expression_ A variable that represents a [Presentation](PowerPoint.Presentation
 
 ## Remarks
 
-When you open a presentation with content that is large in size, PowerPoint may serve the document in parts as partial documents. This allows for documents to be opened, edited, and collaborated upon quickly, while the larger media parts (e.g., videos), continue to load in the background. Similarly, since media is handled separately from the rest of the document, collaboration is smoother when media is inserted during a collaboration session.
+When you open a presentation with content that is large in size, PowerPoint may serve the document in parts as partial documents. This allows you to open, edit, and collaborate on documents quickly, while the larger media parts (e.g., videos), continue to load in the background. Similarly, since media is handled separately from the rest of the document, collaboration is smoother when media is inserted during a collaboration session.
 
-Because certain content can be deferred initially, some actions can't be taken on that content until the deferred content (e.g., video) is loaded. Additionally, there are certain actions like Save As, Export to Video, etc. that won’t function until all the deferred content are downloaded. User initiated operations will display UI informing the user of download progress, but that’s not possible for programmatic operations.  If you programmatically attempt to call an API to execute an action in these cases, it will fail.
+Because certain content can be deferred initially, some actions can't be taken until the deferred content is loaded. Additionally, there are certain actions like Save As, Export to Video, etc. that won’t function until all the deferred content are downloaded. If you initiate one of these operations, PowerPoint will display UI informing you of the download progress, but that’s not possible for programmatic operations. If you programmatically attempt to call an API to execute an action while content is still downloading, it will fail.
 
-To understand this state programmatically, you may query **Presentation.IsFullyDownloaded** property before calling any of the impacted APIs and add error handling to capture the failure and retry the operation once the presentation is fully downloaded.
+To understand this state programmatically, you can query **Presentation.IsFullyDownloaded** property before you call any of the impacted APIs. Add error handling to capture any failures and retry the operation once the presentation is fully downloaded.
 
 ## Example
 
@@ -37,9 +37,9 @@ The following example displays a message indicating if the active presentation i
 
 ```vb
 If ActivePresentation.IsFullyDownloaded Then
-    MsgBox "Everything is downloaded"
+    MsgBox "Presentation is downloaded."
 Else
-    MsgBox "Not fully downloaded"
+    MsgBox "PowerPoint is still downloading the presentation."
 End If
 ```
 

--- a/api/PowerPoint.Presentation.IsFullyDownloaded.md
+++ b/api/PowerPoint.Presentation.IsFullyDownloaded.md
@@ -6,7 +6,7 @@ f1_keywords:
 ms.prod: powerpoint
 api_name:
 - PowerPoint.Presentation.IsFullyDownloaded
-ms.date: 07/27/2022
+ms.date: 08/02/2022
 ms.author: ononder
 ms.localizationpriority: medium
 ---

--- a/api/PowerPoint.Presentation.IsFullyDownloaded.md
+++ b/api/PowerPoint.Presentation.IsFullyDownloaded.md
@@ -1,0 +1,53 @@
+---
+title: Presentation.IsFullyDownloaded property (PowerPoint)
+keywords: vbapp10.chm583138
+f1_keywords:
+- vbapp10.chm583138
+ms.prod: powerpoint
+api_name:
+- PowerPoint.Presentation.IsFullyDownloaded
+ms.date: 07/27/2022
+ms.author: ononder
+ms.localizationpriority: medium
+---
+
+
+# Presentation.IsFullyDownloaded property (PowerPoint)
+
+**True** if the presentation has finished downloading all of the content. Read-only **Boolean.**
+
+## Syntax
+
+_expression_.**IsFullyDownloaded**
+
+_expression_ A variable that represents a [Presentation](PowerPoint.Presentation.md) object.
+
+## Remarks
+
+When you open a presentation with content that is large in size, PowerPoint may serve the document in parts as partial documents. This allows for documents to be opened, edited, and collaborated upon quickly, while the larger media parts (e.g., videos), continue to load in the background. Similarly, since media is handled separately from the rest of the document, collaboration is smoother when media is inserted during a collaboration session.
+
+Because certain content can be deferred initially, some actions can't be taken on that content until the deferred content (e.g., video) is loaded. Additionally, there are certain actions like Save As, Export to Video, etc. that won’t function until all the deferred content are downloaded. User initiated operations will display UI informing the user of download progress, but that’s not possible for programmatic operations.  If you programmatically attempt to call an API to execute an action in these cases, it will fail.
+
+To understand this state programmatically, you may query **Presentation.IsFullyDownloaded** property before calling any of the impacted APIs and add error handling to capture the failure and retry the operation once the presentation is fully downloaded.
+
+## Example
+
+The following example displays a message indicating if the active presentation is fully downloaded or not.
+
+
+```vb
+If ActivePresentation.IsFullyDownloaded Then
+    MsgBox "Everything is downloaded"
+Else
+    MsgBox "Not fully downloaded"
+End If
+```
+
+
+## See also
+
+[Presentation Object](PowerPoint.Presentation.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
+
+[!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Presentation.Password.md
+++ b/api/PowerPoint.Presentation.Password.md
@@ -29,6 +29,11 @@ _expression_ A variable that represents a [Presentation](PowerPoint.Presentation
 String
 
 
+## Remarks
+
+If the presentation is not fully downloaded, the setting of this property fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 ## Example
 
 This example opens Earnings.ppt, sets a password for it, and then closes the presentation.
@@ -55,5 +60,7 @@ End Sub
 
 
 [Presentation Object](PowerPoint.Presentation.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Presentation.Password.md
+++ b/api/PowerPoint.Presentation.Password.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Presentation.Password
 ms.assetid: 977876b7-b40f-de45-c259-e91744915085
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Presentation.SaveAs.md
+++ b/api/PowerPoint.Presentation.SaveAs.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Presentation.SaveAs
 ms.assetid: d70a678b-66ed-9dd6-5a5e-454cdf808784
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Presentation.SaveAs.md
+++ b/api/PowerPoint.Presentation.SaveAs.md
@@ -78,6 +78,8 @@ The  _EmbedFonts_ parameter value can be one of these **MsoTriState** constants.
 |**msoTriStateMixed**|Embedded fonts are a mixture of TrueType and non-TrueType. The default. |
 |**msoTrue**|TrueType fonts are embedded.|
 
+If the presentation is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 ## Example
 
 This example saves a copy of the active presentation under the name "New Format Copy.ppt." By default, this copy is saved in the format of a presentation in the current version of PowerPoint. The presentation is then saved as a PowerPoint 4.0 file named "Old Format Copy."
@@ -95,5 +97,7 @@ End With
 
 
 [Presentation Object](PowerPoint.Presentation.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Presentation.SaveCopyAs.md
+++ b/api/PowerPoint.Presentation.SaveCopyAs.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Presentation.SaveCopyAs
 ms.assetid: 456415d1-845a-9e9b-45ce-98985e94aee5
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Presentation.SaveCopyAs.md
+++ b/api/PowerPoint.Presentation.SaveCopyAs.md
@@ -72,6 +72,8 @@ The  _EmbedTrueTypeFonts_ parameter value can be one of these **MsoTriState** co
 |**msoTriStateMixed**|Embedded fonts are a mixture of TrueType and non-TrueType. The default. |
 |**msoTrue**|TrueType fonts are embedded.|
 
+If the presentation is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 ## Example
 
 This example saves a copy of the active presentation under the name "New Format Copy.ppt." By default, this copy is saved in the format of a presentation in the current version of PowerPoint. The presentation is then saved as a PowerPoint 4.0 file named "Old Format Copy."
@@ -92,5 +94,7 @@ End With
 
 
 [Presentation Object](PowerPoint.Presentation.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Presentation.SaveCopyAs2.md
+++ b/api/PowerPoint.Presentation.SaveCopyAs2.md
@@ -75,6 +75,8 @@ The _ReadOnlyRecommended_ parameter value can be one of these **MsoTriStat
 |**msoTriStateMixed**|The new file will have the same ReadOnlyRecommended state as the original. The default. |
 |**msoTrue**|The new file will be marked as ReadOnlyRecommended. |
 
+If the presentation is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 ## Example
 
 This example saves a copy of the active presentation under the name "New File.pptx" while removing the ReadOnlyRecommended flag.  
@@ -90,5 +92,7 @@ End With
 ## See also
 
 [Presentation Object](PowerPoint.Presentation.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Presentation.SaveCopyAs2.md
+++ b/api/PowerPoint.Presentation.SaveCopyAs2.md
@@ -8,7 +8,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Presentation.SaveCopyAs2
 ms.author: lindalu
-ms.date: 09/18/2020
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Presentation.WritePassword.md
+++ b/api/PowerPoint.Presentation.WritePassword.md
@@ -29,6 +29,11 @@ _expression_ A variable that represents a [Presentation](PowerPoint.Presentation
 String
 
 
+## Remarks
+
+If the presentation is not fully downloaded, the setting of this property fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 ## Example
 
 This example sets the password for saving changes to the active presentation.
@@ -47,5 +52,7 @@ End Sub
 
 
 [Presentation Object](PowerPoint.Presentation.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Presentation.WritePassword.md
+++ b/api/PowerPoint.Presentation.WritePassword.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Presentation.WritePassword
 ms.assetid: 42381e81-c5d0-3db1-f214-6619bbc6711f
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Presentation.md
+++ b/api/PowerPoint.Presentation.md
@@ -145,6 +145,7 @@ MsgBox SlideShowWindows(1).Presentation.Name
 |[HasTitleMaster](PowerPoint.Presentation.HasTitleMaster.md)|
 |[HasVBProject](PowerPoint.Presentation.HasVBProject.md)|
 |[InMergeMode](PowerPoint.Presentation.InMergeMode.md)|
+|[IsFullyDownloaded](PowerPoint.Presentation.IsFullyDownloaded.md)|
 |[LayoutDirection](PowerPoint.Presentation.LayoutDirection.md)|
 |[Name](PowerPoint.Presentation.Name.md)|
 |[NoLineBreakAfter](PowerPoint.Presentation.NoLineBreakAfter.md)|

--- a/api/PowerPoint.Selection.Copy.md
+++ b/api/PowerPoint.Selection.Copy.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Selection.Copy
 ms.assetid: 954106da-a2a9-0c55-114a-5a79f578e0c4
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Selection.Copy.md
+++ b/api/PowerPoint.Selection.Copy.md
@@ -28,6 +28,8 @@ _expression_ A variable that represents a [Selection](PowerPoint.Selection.md) o
 
 Use the **Paste** method to paste the contents of the Clipboard.
 
+If the selected content is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 
 ## Example
 
@@ -45,5 +47,7 @@ Windows(2).View.Paste
 
 
 [Selection Object](PowerPoint.Selection.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Selection.Cut.md
+++ b/api/PowerPoint.Selection.Cut.md
@@ -24,6 +24,11 @@ _expression_.**Cut**
 _expression_ A variable that represents a [Selection](PowerPoint.Selection.md) object.
 
 
+## Remarks
+
+If the selected content is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 ## Example
 
 This example deletes the selection in window one and places a copy of it on the Clipboard.
@@ -38,5 +43,7 @@ Windows(1).Selection.Cut
 
 
 [Selection Object](PowerPoint.Selection.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Selection.Cut.md
+++ b/api/PowerPoint.Selection.Cut.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Selection.Cut
 ms.assetid: 305103ad-f4d1-8173-e331-17750587d865
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Shape.Copy.md
+++ b/api/PowerPoint.Shape.Copy.md
@@ -28,6 +28,8 @@ _expression_ A variable that represents a **[Shape](PowerPoint.Shape.md)** objec
 
 Use the **Paste** method to paste the contents of the Clipboard.
 
+If the shape is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 
 ## Example
 
@@ -49,5 +51,7 @@ End With
 
 
 [Shape Object](PowerPoint.Shape.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Shape.Copy.md
+++ b/api/PowerPoint.Shape.Copy.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Shape.Copy
 ms.assetid: 41c82fd1-9ee7-c937-0a75-77b84c33c972
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Shape.Cut.md
+++ b/api/PowerPoint.Shape.Cut.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Shape.Cut
 ms.assetid: 908c998d-a15f-5075-33e0-de6c124a0ec7
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Shape.Cut.md
+++ b/api/PowerPoint.Shape.Cut.md
@@ -24,6 +24,11 @@ _expression_.**Cut**
 _expression_ A variable that represents a **[Shape](PowerPoint.Shape.md)** object.
 
 
+## Remarks
+
+If the shape is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 ## Example
 
 This example deletes shapes one and two from slide one in the active presentation, places copies of them on the Clipboard, and then pastes the copies onto slide two.
@@ -44,5 +49,7 @@ End With
 
 
 [Shape Object](PowerPoint.Shape.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.ShapeRange.Copy.md
+++ b/api/PowerPoint.ShapeRange.Copy.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.ShapeRange.Copy
 ms.assetid: ddc0dad9-6647-e2f4-393a-347c273656dd
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.ShapeRange.Copy.md
+++ b/api/PowerPoint.ShapeRange.Copy.md
@@ -28,6 +28,8 @@ _expression_ A variable that represents a **[ShapeRange](PowerPoint.ShapeRange.m
 
 Use the **Paste** method to paste the contents of the Clipboard.
 
+If any shape in the range is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 
 ## Example
 
@@ -49,5 +51,7 @@ End With
 
 
 [ShapeRange Object](PowerPoint.ShapeRange.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.ShapeRange.Cut.md
+++ b/api/PowerPoint.ShapeRange.Cut.md
@@ -24,6 +24,11 @@ _expression_.**Cut**
 _expression_ A variable that represents a **[ShapeRange](PowerPoint.ShapeRange.md)** object.
 
 
+## Remarks
+
+If any shape in the range is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 ## Example
 
 This example deletes shapes one and two from slide one in the active presentation, places copies of them on the Clipboard, and then pastes the copies onto slide two.
@@ -44,5 +49,7 @@ End With
 
 
 [ShapeRange Object](PowerPoint.ShapeRange.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.ShapeRange.Cut.md
+++ b/api/PowerPoint.ShapeRange.Cut.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.ShapeRange.Cut
 ms.assetid: 0e86d67c-7d52-4f3a-4cdd-6363667600a1
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Shapes.Paste.md
+++ b/api/PowerPoint.Shapes.Paste.md
@@ -41,6 +41,8 @@ Use the **[ViewType](PowerPoint.DocumentWindow.ViewType.md)** property to set th
 |Outline view|Text or entire slides. You cannot paste shapes into outline view. A pasted slide will be inserted before the slide that contains the cursor.|
 |Slide sorter view|Entire slides. You cannot paste shapes or text into slide sorter view. A pasted slide will be inserted at the cursor or after the last slide selected in the presentation.|
 
+If the source content is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 ## Example
 
 This example copies shape one on slide one in the active presentation to the Clipboard and then pastes it into slide two.
@@ -76,5 +78,7 @@ End With
 
 
 [Shapes Object](PowerPoint.Shapes.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Shapes.Paste.md
+++ b/api/PowerPoint.Shapes.Paste.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Shapes.Paste
 ms.assetid: 8aa534f8-bd59-3945-cc1f-45ffc3883bf7
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Shapes.PasteSpecial.md
+++ b/api/PowerPoint.Shapes.PasteSpecial.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Shapes.PasteSpecial
 ms.assetid: 6a1e5b6d-da09-fae8-7165-0c9bf71d525c
-ms.date: 11/24/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 
@@ -68,8 +68,12 @@ The _DisplayAsIcon_ parameter value can be one of these **MsoTriState** constant
 
 An error occurs if there is no data on the Clipboard when the **PasteSpecial** method is called.
 
+If the source content is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 ## See also
 
 [Shapes Object](PowerPoint.Shapes.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Slide.Copy.md
+++ b/api/PowerPoint.Slide.Copy.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Slide.Copy
 ms.assetid: 35844287-a2f3-463d-f735-d88f383ad208
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Slide.Copy.md
+++ b/api/PowerPoint.Slide.Copy.md
@@ -28,6 +28,8 @@ _expression_ A variable that represents a [Slide](PowerPoint.Slide.md) object.
 
 Use the **Paste** method to paste the contents of the Clipboard.
 
+If the slide is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 
 ## Example
 
@@ -43,5 +45,7 @@ ActivePresentation.Slides(1).Copy
 
 
 [Slide Object](PowerPoint.Slide.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Slide.Cut.md
+++ b/api/PowerPoint.Slide.Cut.md
@@ -24,6 +24,11 @@ _expression_.**Cut**
 _expression_ A variable that represents a [Slide](PowerPoint.Slide.md) object.
 
 
+## Remarks
+
+If the slide is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 ## Example
 
 This example deletes slide one from the active presentation and places a copy of it on the Clipboard.
@@ -38,5 +43,7 @@ ActivePresentation.Slides(1).Cut
 
 
 [Slide Object](PowerPoint.Slide.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Slide.Cut.md
+++ b/api/PowerPoint.Slide.Cut.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Slide.Cut
 ms.assetid: 03029017-52c8-5176-a218-8b5ff8edec10
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.Slide.Export.md
+++ b/api/PowerPoint.Slide.Export.md
@@ -41,6 +41,8 @@ Exporting a presentation doesn't set the **[Saved](PowerPoint.Presentation.Saved
 
 PowerPoint uses the specified graphics filter to save each individual slide. The names of the slides exported and saved to disk are determined by PowerPoint. They are typically saved by using names such as Slide1.wmf, Slide2.wmf. The path of the saved files is specified in the FileName argument.
 
+If the slide is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 
 ## Example
 
@@ -59,5 +61,7 @@ End With
 
 
 [Slide Object](PowerPoint.Slide.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Slide.Export.md
+++ b/api/PowerPoint.Slide.Export.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Slide.Export
 ms.assetid: b7379dfa-ce0b-340d-9109-5970beb77aa3
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.SlideRange.Copy.md
+++ b/api/PowerPoint.SlideRange.Copy.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.SlideRange.Copy
 ms.assetid: d781370d-8107-efaa-77ea-a7f1aa58737b
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.SlideRange.Copy.md
+++ b/api/PowerPoint.SlideRange.Copy.md
@@ -28,6 +28,8 @@ _expression_ A variable that represents a [SlideRange](PowerPoint.SlideRange.md)
 
 Use the **Paste** method to paste the contents of the Clipboard.
 
+If any slide in the range is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 
 ## Example
 
@@ -43,5 +45,7 @@ ActivePresentation.Slides(1).Copy
 
 
 [SlideRange Object](PowerPoint.SlideRange.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.SlideRange.Cut.md
+++ b/api/PowerPoint.SlideRange.Cut.md
@@ -24,6 +24,11 @@ _expression_.**Cut**
 _expression_ A variable that represents a [SlideRange](PowerPoint.SlideRange.md) object.
 
 
+## Remarks
+
+If any slide in the range is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 ## Example
 
 This example deletes shapes one and two from slide one in the active presentation, places copies of them on the Clipboard, and then pastes the copies onto slide two.
@@ -44,5 +49,7 @@ End With
 
 
 [SlideRange Object](PowerPoint.SlideRange.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.SlideRange.Cut.md
+++ b/api/PowerPoint.SlideRange.Cut.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.SlideRange.Cut
 ms.assetid: 91d80a2b-e67a-290b-cb41-6bbeeb467d1b
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.SlideRange.Export.md
+++ b/api/PowerPoint.SlideRange.Export.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.SlideRange.Export
 ms.assetid: a14b5d03-e6c4-486e-a97b-1c9bd1a18769
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.SlideRange.Export.md
+++ b/api/PowerPoint.SlideRange.Export.md
@@ -41,10 +41,14 @@ Exporting a presentation doesn't set the **[Saved](PowerPoint.Presentation.Saved
 
 PowerPoint uses the specified graphics filter to save each individual slide. The names of the slides exported and saved to disk are determined by PowerPoint. They are typically saved by using the following naming convention: Slide1.wmf, Slide2.wmf. The path of the saved files is specified in the FileName argument.
 
+If any slide in the range is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 
 ## See also
 
 
 [SlideRange Object](PowerPoint.SlideRange.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Slides.Paste.md
+++ b/api/PowerPoint.Slides.Paste.md
@@ -49,6 +49,9 @@ Use the **[ViewType](PowerPoint.DocumentWindow.ViewType.md)** property to set th
 |Outline view|Text or entire slides. You cannot paste shapes into outline view. A pasted slide will be inserted before the slide that contains the cursor.|
 |Slide sorter view|Entire slides. You cannot paste shapes or text into slide sorter view. A pasted slide will be inserted at the cursor or after the last slide selected in the presentation.|
 
+If the source content is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 ## Example
 
 This example cuts slides three and five from the Old Sales presentation and then inserts them before slide four in the active presentation.
@@ -65,5 +68,7 @@ ActivePresentation.Slides.Paste 4
 
 
 [Slides Object](PowerPoint.Slides.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.Slides.Paste.md
+++ b/api/PowerPoint.Slides.Paste.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.Slides.Paste
 ms.assetid: 313027d1-6f8b-9964-f0bd-4ba33c973743
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.View.Paste.md
+++ b/api/PowerPoint.View.Paste.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.View.Paste
 ms.assetid: e7878c74-92d7-8993-9b46-8647c1b59b15
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.View.Paste.md
+++ b/api/PowerPoint.View.Paste.md
@@ -38,6 +38,9 @@ Use the **[ViewType](PowerPoint.DocumentWindow.ViewType.md)** property to set th
 |Outline view|Text or entire slides. You cannot paste shapes into outline view. A pasted slide will be inserted before the slide that contains the cursor.|
 |Slide sorter view|Entire slides. You cannot paste shapes or text into slide sorter view. A pasted slide will be inserted at the cursor or after the last slide selected in the presentation.|
 
+If the source content is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 ## Example
 
 This example copies the selection in window one to the Clipboard and copies it into the view in window two. If the Clipboard contents cannot be pasted into the view in window two (for example, if you try to paste a shape into slide sorter view), this example fails.
@@ -73,5 +76,7 @@ End With
 
 
 [View Object](PowerPoint.View.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.View.PasteSpecial.md
+++ b/api/PowerPoint.View.PasteSpecial.md
@@ -75,6 +75,9 @@ The Link parameter can be one of these **MsoTriState** constants.
 |**msoFalse** The default. Does not create a link to the source file of the Clipboard contents.|
 |**msoTrue** Creates a link to the source file of the Clipboard contents.|
 
+If the source content is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 ## Example
 
 The following example pastes a bitmap image as an icon into another window. This example assumes that there are two open windows and that a bitmap image in the first window is currently selected.
@@ -95,5 +98,7 @@ End Sub
 
 
 [View Object](PowerPoint.View.md)
+
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.View.PasteSpecial.md
+++ b/api/PowerPoint.View.PasteSpecial.md
@@ -7,7 +7,7 @@ ms.prod: powerpoint
 api_name:
 - PowerPoint.View.PasteSpecial
 ms.assetid: 074fb28f-19c6-3c0f-21ae-75012614485e
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.localizationpriority: medium
 ---
 

--- a/api/PowerPoint.player.play.md
+++ b/api/PowerPoint.player.play.md
@@ -4,7 +4,7 @@ keywords: vbapp10.chm726003
 f1_keywords:
 - vbapp10.chm726003
 ms.assetid: 784de3da-846e-fb9d-bc14-6ba453904d30
-ms.date: 06/08/2017
+ms.date: 08/02/2022
 ms.prod: powerpoint
 ms.localizationpriority: medium
 ---

--- a/api/PowerPoint.player.play.md
+++ b/api/PowerPoint.player.play.md
@@ -26,4 +26,10 @@ _expression_ A variable that represents a [Player](PowerPoint.Player.md) object.
 
  **VOID**
 
+
+## Remarks
+
+If the media content is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
+
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.presentation.exportasfixedformat2.md
+++ b/api/PowerPoint.presentation.exportasfixedformat2.md
@@ -4,7 +4,7 @@ keywords: vbapp10.chm583126
 f1_keywords:
 - vbapp10.chm583126
 ms.assetid: b1101e58-e6a8-9dd4-7071-1325ba71edb1
-ms.date: 07/22/2022
+ms.date: 08/02/2022
 ms.prod: powerpoint
 ms.localizationpriority: medium
 ---
@@ -68,9 +68,11 @@ The _KeepIRMSettings_ parameter behaves specially for PDF. It controls the reten
 
 Due to the interaction of partner add-ins creating PDFs in Office with encryption, Office will default the _KeepIRMSettings_ flag to **FALSE** until [second RMID (93406)](https://www.microsoft.com/microsoft-365/roadmap?filters=&searchterms=93406) releases. For complete details how to adapt to this change, read the [Changes in Export to PDF with sensitivity labeling and encryption in Office Add-ins](https://devblogs.microsoft.com/microsoft365dev/changes-in-export-to-pdf-with-sensitivity-labelling-and-encryption-in-office-add-ins/) blog post by Chris Dietsch.
 
+If the presentation is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 ### See also
 [Manage sensitivity labels in Office apps](/microsoft-365/compliance/sensitivity-labels-office-apps?view=o365-worldwide#pdf-support&preserve-view=true)
 
-If the presentation is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+[Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md)
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/PowerPoint.presentation.exportasfixedformat2.md
+++ b/api/PowerPoint.presentation.exportasfixedformat2.md
@@ -71,4 +71,6 @@ Due to the interaction of partner add-ins creating PDFs in Office with encryptio
 ### See also
 [Manage sensitivity labels in Office apps](/microsoft-365/compliance/sensitivity-labels-office-apps?view=o365-worldwide#pdf-support&preserve-view=true)
 
+If the presentation is not fully downloaded, this method fails and an error occurs. For more information about the Partial Documents, see [Work with Partial Documents](~/powerpoint/How-to/work-with-partial-documents.md).
+
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/powerpoint/How-to/work-with-partial-documents.md
+++ b/powerpoint/How-to/work-with-partial-documents.md
@@ -25,7 +25,7 @@ Run-time error '-2147188128 (80048260)':
 
 ## Understanding the Fully Downloaded State
 
-To understand if a presentation is fully downloaded programmatically, you may query [Presentation.IsFullyDownloaded](~/api/PowerPoint.IsFullyDownloaded.md) property before calling any of the impacted APIs.
+To understand if a presentation is fully downloaded programmatically, you may query [Presentation.IsFullyDownloaded](~/api/PowerPoint.Presentation.IsFullyDownloaded.md) property before calling any of the impacted APIs.
 
 
 ```vb

--- a/powerpoint/How-to/work-with-partial-documents.md
+++ b/powerpoint/How-to/work-with-partial-documents.md
@@ -10,11 +10,11 @@ ms.localizationpriority: medium
 ---
 
 
-# Work with Partial Documents
+# Work with partial documents
 
-When you open a presentation with content that is large in size, PowerPoint may serve the document in parts as partial documents. This allows for documents to be opened, edited, and collaborated upon quickly, while the larger media parts (e.g., videos), continue to load in the background. Similarly, since media is handled separately from the rest of the document, collaboration is smoother when media is inserted during a collaboration session.
+When you open a presentation with content that is large in size, PowerPoint may serve the document in parts as partial documents. This allows you to open, edit, and collaborate on documents quickly, while the larger media parts (e.g., videos), continue to load in the background. Similarly, since media is handled separately from the rest of the document, collaboration is smoother when media is inserted during a collaboration session.
 
-Because certain content can be deferred initially, some actions can't be taken on that content until the deferred content (e.g., video) is loaded. Additionally, there are certain actions like Save As, Export to Video, etc. that won’t function until all the deferred content are downloaded. User initiated operations will display UI informing the user of download progress, but that’s not possible for programmatic operations.  If you programmatically attempt to call an API to execute an action in these cases, it will fail with the following error message.
+Because certain content can be deferred initially, some actions can't be taken until the deferred content is loaded. Additionally, there are certain actions like Save As, Export to Video, etc. that won’t function until all the deferred content are downloaded. If you initiate one of these operations, PowerPoint will display UI informing you of the download progress, but that’s not possible for programmatic operations. If you programmatically attempt to call an API to execute an action while content is still downloading, it will fail.
 
 
 ```
@@ -23,24 +23,24 @@ Run-time error '-2147188128 (80048260)':
 ```
 
 
-## Understanding the Fully Downloaded State
+## Understand the fully downloaded state
 
 To understand if a presentation is fully downloaded programmatically, you may query [Presentation.IsFullyDownloaded](~/api/PowerPoint.Presentation.IsFullyDownloaded.md) property before calling any of the impacted APIs.
 
 
 ```vb
 If ActivePresentation.IsFullyDownloaded Then
-    MsgBox "Everything is downloaded"
+    MsgBox "Presentation download is complete."
 Else
-    MsgBox "Not fully downloaded"
+    MsgBox "PowerPoint is still downloading the presentation."
 End If
 ```
 
 
-## Handling Errors
+## Error handling
 
  You may also add some error handling to capture the failure and retry the operation once the presentation is fully downloaded. If the error value is `-2147188128` or `0x80048260`, the operation has failed because the presentation is not fully downloaded.
-**Err.Number** can be used as a key to identify these failures.
+Use **Err.Number** as a key to identify these failures, as show in the following example.
 
 
 ```vb
@@ -50,9 +50,9 @@ Sub TestCopySlide()
     Exit Sub
 eh:
     If Err.Number = -2147188128 Then
-        MsgBox "Cannot copy because the presentation is not fully downloaded"
+        MsgBox "Cannot copy because the presentation is not fully downloaded."
     Else
-        MsgBox "Failed due to reason other than incomplete parts: " & Err.Description
+        MsgBox "Failure is due to a reason other than incomplete download: " & Err.Description.
     End If
     Debug.Print Err.Number, Err.Description
 End Sub

--- a/powerpoint/How-to/work-with-partial-documents.md
+++ b/powerpoint/How-to/work-with-partial-documents.md
@@ -1,0 +1,98 @@
+---
+title: Work with Partial Documents
+keywords: vbapp10.chm583138
+f1_keywords:
+- vbapp10.chm583138
+ms.prod: powerpoint
+ms.date: 07/27/2022
+ms.author: ononder
+ms.localizationpriority: medium
+---
+
+
+# Work with Partial Documents
+
+When you open a presentation with content that is large in size, PowerPoint may serve the document in parts as partial documents. This allows for documents to be opened, edited, and collaborated upon quickly, while the larger media parts (e.g., videos), continue to load in the background. Similarly, since media is handled separately from the rest of the document, collaboration is smoother when media is inserted during a collaboration session.
+
+Because certain content can be deferred initially, some actions can't be taken on that content until the deferred content (e.g., video) is loaded. Additionally, there are certain actions like Save As, Export to Video, etc. that won’t function until all the deferred content are downloaded. User initiated operations will display UI informing the user of download progress, but that’s not possible for programmatic operations.  If you programmatically attempt to call an API to execute an action in these cases, it will fail with the following error message.
+
+
+```
+Run-time error '-2147188128 (80048260)':
+<object> (unknown member) : This method isn't supported until the presentation is fully downloaded. Visit this URL for more information: https://go.microsoft.com/fwlink/?linkid=2172228
+```
+
+
+## Understanding the Fully Downloaded State
+
+To understand if a presentation is fully downloaded programmatically, you may query [Presentation.IsFullyDownloaded](~/api/PowerPoint.IsFullyDownloaded.md) property before calling any of the impacted APIs.
+
+
+```vb
+If ActivePresentation.IsFullyDownloaded Then
+    MsgBox "Everything is downloaded"
+Else
+    MsgBox "Not fully downloaded"
+End If
+```
+
+
+## Handling Errors
+
+ You may also add some error handling to capture the failure and retry the operation once the presentation is fully downloaded. If the error value is `-2147188128` or `0x80048260`, the operation has failed because the presentation is not fully downloaded.
+**Err.Number** can be used as a key to identify these failures.
+
+
+```vb
+Sub TestCopySlide()
+    On Error GoTo eh    
+    ActivePresentation.Slides(1).Copy    
+    Exit Sub
+eh:
+    If Err.Number = -2147188128 Then
+        MsgBox "Cannot copy because the presentation is not fully downloaded"
+    Else
+        MsgBox "Failed due to reason other than incomplete parts: " & Err.Description
+    End If
+    Debug.Print Err.Number, Err.Description
+End Sub
+```
+
+
+## Impacted APIs
+
+The following is a list of impacted OM API calls which may return the error code:
+
+|Name|
+|:-----|
+|[Presentation.Export](~/api/PowerPoint.Presentation.Export.md)|
+|[Presentation.ExportAsFixedFormat](~/api/PowerPoint.Presentation.ExportAsFixedFormat.md)|
+|[Presentation.ExportAsFixedFormat2](~/api/PowerPoint.Presentation.ExportAsFixedFormat2.md)|
+|[Presentation.SaveAs](~/api/PowerPoint.Presentation.SaveAs.md)|
+|[Presentation.SaveCopyAs](~/api/PowerPoint.Presentation.SaveCopyAs.md)|
+|[Presentation.SaveCopyAs2](~/api/PowerPoint.Presentation.SaveCopyAs2.md)|
+|[Presentation.Password](~/api/PowerPoint.Presentation.Password.md)|
+|[Presentation.WritePassword](~/api/PowerPoint.Presentation.WritePassword.md)|
+|[Selection.Copy](~/api/PowerPoint.Selection.Copy.md)|
+|[Selection.Cut](~/api/PowerPoint.Selection.Cut.md)|
+|[Shape.Copy](~/api/PowerPoint.Shape.Copy.md)|
+|[Shape.Cut](~/api/PowerPoint.Shape.Cut.md)|
+|[ShapeRange.Cut](~/api/PowerPoint.ShapeRange.Cut.md)|
+|[ShapeRange.Copy](~/api/PowerPoint.ShapeRange.Copy.md)|
+|[Shapes.Paste](~/api/PowerPoint.Shapes.Paste.md)|
+|[Slide.Copy](~/api/PowerPoint.Slide.Copy.md)|
+|[Slide.Cut](~/api/PowerPoint.Slide.Cut.md)|
+|[Slide.Export](~/api/PowerPoint.Slide.Export.md)|
+|[SlideRange.Copy](~/api/PowerPoint.SlideRange.Copy.md)|
+|[SlideRange.Cut](~/api/PowerPoint.SlideRange.Cut.md)|
+|[SlideRange.Export](~/api/PowerPoint.SlideRange.Export.md)|
+|[Slides.Paste](~/api/PowerPoint.Slides.Paste.md)|
+|[CustomLayouts.Paste](~/api/PowerPoint.CustomLayouts.Paste.md)|
+|[View.Paste](~/api/PowerPoint.View.Paste.md)|
+|[View.PasteSpecial](~/api/PowerPoint.View.PasteSpecial.md)|
+|[MediaFormat.Resample](~/api/PowerPoint.MediaFormat.Resample.md)|
+|[MediaFormat.ResampleFromProfile](~/api/PowerPoint.MediaFormat.ResampleFromProfile.md)|
+|[Player.Play](~/api/PowerPoint.Player.Play.md)|
+
+
+[!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/powerpoint/How-to/work-with-partial-documents.md
+++ b/powerpoint/How-to/work-with-partial-documents.md
@@ -4,7 +4,7 @@ keywords: vbapp10.chm583138
 f1_keywords:
 - vbapp10.chm583138
 ms.prod: powerpoint
-ms.date: 07/27/2022
+ms.date: 08/02/2022
 ms.author: ononder
 ms.localizationpriority: medium
 ---
@@ -80,6 +80,7 @@ The following is a list of impacted OM API calls which may return the error code
 |[ShapeRange.Cut](~/api/PowerPoint.ShapeRange.Cut.md)|
 |[ShapeRange.Copy](~/api/PowerPoint.ShapeRange.Copy.md)|
 |[Shapes.Paste](~/api/PowerPoint.Shapes.Paste.md)|
+|[Shapes.PasteSpecial](~/api/PowerPoint.Shapes.PasteSpecial.md)|
 |[Slide.Copy](~/api/PowerPoint.Slide.Copy.md)|
 |[Slide.Cut](~/api/PowerPoint.Slide.Cut.md)|
 |[Slide.Export](~/api/PowerPoint.Slide.Export.md)|


### PR DESCRIPTION
## Adding VBA/OM changes for PowerPoint partial documents support documentation.

Added a How-To page: powerpoint\How-to\work-with-partial-documents.md

Added new API: api\PowerPoint.Presentation.IsFullyDownloaded.md
Help context id (f1_keywords) is 583138 (0x0008e5e2)

(I used the same help context id for how to page as well, let me know if that was wrong)
(I believe I was able to correctly link between pages, please double check the link syntax going for how to page)

Updated existing APIs:

- api\PowerPoint.CustomLayouts.Paste.md
- api\PowerPoint.MediaFormat.Resample.md
- api\PowerPoint.MediaFormat.ResampleFromProfile.md
- api\PowerPoint.Presentation.Export.md
- api\PowerPoint.Presentation.ExportAsFixedFormat.md
- api\PowerPoint.Presentation.Password.md
- api\PowerPoint.Presentation.SaveAs.md
- api\PowerPoint.Presentation.SaveCopyAs.md
- api\PowerPoint.Presentation.SaveCopyAs2.md
- api\PowerPoint.Presentation.WritePassword.md
- api\PowerPoint.Selection.Copy.md
- api\PowerPoint.Selection.Cut.md
- api\PowerPoint.Shape.Copy.md
- api\PowerPoint.Shape.Cut.md
- api\PowerPoint.ShapeRange.Copy.md
- api\PowerPoint.ShapeRange.Cut.md
- api\PowerPoint.Shapes.Paste.md
- api\PowerPoint.Shapes.PasteSpecial.md
- api\PowerPoint.Slide.Copy.md
- api\PowerPoint.Slide.Cut.md
- api\PowerPoint.Slide.Export.md
- api\PowerPoint.SlideRange.Copy.md
- api\PowerPoint.SlideRange.Cut.md
- api\PowerPoint.SlideRange.Export.md
- api\PowerPoint.Slides.Paste.md
- api\PowerPoint.View.Paste.md
- api\PowerPoint.View.PasteSpecial.md
- api\PowerPoint.player.play.md
- api\PowerPoint.presentation.exportasfixedformat2.md
