### PR TITLE
Update Excel.OLEObjects.md

### DIFF
--- a/api/Excel.OLEObjects.md
+++ b/api/Excel.OLEObjects.md
@@ -23,7 +23,7 @@ Each **OLEObject** object represents an ActiveX control or a linked or embedded 
 
 An ActiveX control on a sheet has two names: the name of the shape that contains the control, which you can see in the **Name** box when you view the sheet, and the code name for the control, which you can see in the cell to the right of **(Name)** in the Properties window. 
 
-When you first add a control to a sheet, the shape name and code name match. However, if you change either the shape name or code name, the other is not automatically changed to match.
+When you first add a control to a sheet, the shape name and code name match. However, if you change either the shape name or code name, the other is not automatically changed to match. The latter however, seems to have changed with Excel versions. With version 16.0 both are kept consistent and is not possible to change one of the two alone.
 
 
 ## Example


### PR DESCRIPTION
The sentence: "When you first add a control to a sheet, the shape name and code name match. However, if you change either the shape name or code name, the other is not automatically changed to match."
seems to be no longer true with newer Excel versions. I was unable to get the Name and the Code Name inconsistent by any means.