### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/api/Outlook.ContactItem.EntryID.md
+++ b/api/Outlook.ContactItem.EntryID.md
@@ -26,7 +26,7 @@ _expression_ A variable that represents a [ContactItem](Outlook.ContactItem.md) 
 
 This property corresponds to the MAPI property **PidTagEntryId**.
 
-A MAPI store provider assigns a unique ID string when an item is created in its store. Therefore, the **EntryID** property is not set for an Outlook item until it is saved or sent. The Entry ID changes when an item is moved into another store, for example, from your **Inbox** to a Microsoft Exchange Server public folder, or from one Personal Folders (.pst) file to another .pst file. Solutions should not depend on the **EntryID** property to be unique unless items will not be moved. The **EntryID** property returns a MAPI long-term Entry ID. For more information about long- and short-term **EntryID**s, search [Microsoft Docs](/) for **PidTagEntryId**.
+A MAPI store provider assigns a unique ID string when an item is created in its store. Therefore, the **EntryID** property is not set for an Outlook item until it is saved or sent. The Entry ID changes when an item is moved into another store, for example, from your **Inbox** to a Microsoft Exchange Server public folder, or from one Personal Folders (.pst) file to another .pst file. Solutions should not depend on the **EntryID** property to be unique unless items will not be moved. The **EntryID** property returns a MAPI long-term Entry ID. For more information about long- and short-term **EntryID**s, search [Microsoft Learn](/) for **PidTagEntryId**.
 
 ## Example
 


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
