### PR TITLE
Add api_name to Excel.CategoryCollecion pages

### DIFF
--- a/api/Excel.categorycollection.application.md
+++ b/api/Excel.categorycollection.application.md
@@ -4,6 +4,8 @@ keywords: vbaxl10.chm947073
 f1_keywords:
 - vbaxl10.chm947073
 ms.prod: excel
+api_name:
+- Excel.CategoryCollection.Application
 ms.assetid: cfae4e60-9cda-c43b-e1d5-78ba110dd21c
 ms.date: 04/16/2019
 ms.localizationpriority: medium

--- a/api/Excel.categorycollection.count.md
+++ b/api/Excel.categorycollection.count.md
@@ -4,6 +4,8 @@ keywords: vbaxl10.chm948074
 f1_keywords:
 - vbaxl10.chm948074
 ms.prod: excel
+api_name:
+- Excel.CategoryCollection.Count
 ms.assetid: 7d6c8a5c-75fb-f414-590d-1b0ea8d8ff22
 ms.date: 04/16/2019
 ms.localizationpriority: medium

--- a/api/Excel.categorycollection.creator.md
+++ b/api/Excel.categorycollection.creator.md
@@ -4,6 +4,8 @@ keywords: vbaxl10.chm947074
 f1_keywords:
 - vbaxl10.chm947074
 ms.prod: excel
+api_name:
+- Excel.CategoryCollection.Creator
 ms.assetid: dc0d57e5-5b48-34a9-cca4-360ea927adb1
 ms.date: 04/16/2019
 ms.localizationpriority: medium

--- a/api/Excel.categorycollection.item.md
+++ b/api/Excel.categorycollection.item.md
@@ -4,6 +4,8 @@ keywords: vbaxl10.chm948075
 f1_keywords:
 - vbaxl10.chm948075
 ms.prod: excel
+api_name:
+- Excel.CategoryCollection.Item
 ms.assetid: 799a7fc6-e44b-e860-2806-2f816008a905
 ms.date: 04/16/2019
 ms.localizationpriority: medium

--- a/api/Excel.categorycollection.md
+++ b/api/Excel.categorycollection.md
@@ -4,6 +4,8 @@ keywords: vbaxl10.chm947072
 f1_keywords:
 - vbaxl10.chm947072
 ms.prod: excel
+api_name:
+- Excel.CategoryCollection
 ms.assetid: 5fc7e8c2-6fcb-8726-36f8-d4ae8c2c91e1
 ms.date: 03/28/2019
 ms.localizationpriority: medium

--- a/api/Excel.categorycollection.parent.md
+++ b/api/Excel.categorycollection.parent.md
@@ -4,6 +4,8 @@ keywords: vbaxl10.chm948073
 f1_keywords:
 - vbaxl10.chm948073
 ms.prod: excel
+api_name:
+- Excel.CategoryCollection.Parent
 ms.assetid: b91d60e8-e3a5-42d7-ca93-78469e8bd11b
 ms.date: 04/16/2019
 ms.localizationpriority: medium


### PR DESCRIPTION
The `api_key` property is missing from some pages. This is interfiring with a project of mine.
I see no obvious reason why `Excel.CategoryCollecion` shouldn't include an `api-key` as most other pages.