### PR TITLE
Fix front matter formatting of Excel.WorksheetFunction.FindB

### DIFF
--- a/api/Excel.WorksheetFunction.FindB.md
+++ b/api/Excel.WorksheetFunction.FindB.md
@@ -1,11 +1,11 @@
 ---
-title: WorksheetFunction.**FindB** method (Excel)
+title: WorksheetFunction.FindB method (Excel)
 keywords: vbaxl10.chm137154
 f1_keywords:
 - vbaxl10.chm137154
 ms.prod: excel
 api_name:
-- Excel.WorksheetFunction.**FindB**
+- Excel.WorksheetFunction.FindB
 ms.assetid: 463309cb-7747-6ee4-899b-677222e2dbda
 ms.date: 05/22/2019
 ms.localizationpriority: medium


### PR DESCRIPTION
The front matter of [Excel.WorksheetFunction.FindB.md](https://github.com/MicrosoftDocs/VBA-Docs/blob/2e011e42c67951e112f4dac5f4c6d91f6fa13406/api/Excel.WorksheetFunction.FindB.md) includes some asterics which are not supposed to be there.