### PR TITLE
Fix `Excel.Databar` typo

### DIFF
--- a/api/Excel.Databar.md
+++ b/api/Excel.Databar.md
@@ -1,29 +1,29 @@
 ---
-title: DataBar object (Excel)
+title: Databar object (Excel)
 keywords: vbaxl10.chm809072
 f1_keywords:
 - vbaxl10.chm809072
 ms.prod: excel
 api_name:
-- Excel.DataBar
+- Excel.Databar
 ms.assetid: 2684e913-c278-e6be-ba9d-053b6ad58bae
 ms.date: 03/29/2019
 ms.localizationpriority: medium
 ---
 
 
-# DataBar object (Excel)
+# Databar object (Excel)
 
 Represents a data bar conditional formating rule. Applying a data bar to a range helps you see the value of a cell relative to other cells.
 
 
 ## Remarks
 
-All conditional formatting objects are contained within a **[FormatConditions](Excel.FormatConditions.md)** collection object, which is a child of a **[Range](Excel.Range(object).md)** collection. You can create a data bar formatting rule by using either the **[Add](Excel.FormatConditions.Add.md)** or **[AddDataBar](Excel.FormatConditions.AddDatabar.md)** methods of the **FormatConditions** collection.
+All conditional formatting objects are contained within a **[FormatConditions](Excel.FormatConditions.md)** collection object, which is a child of a **[Range](Excel.Range(object).md)** collection. You can create a data bar formatting rule by using either the **[Add](Excel.FormatConditions.Add.md)** or **[AddDatabar](Excel.FormatConditions.AddDatabar.md)** methods of the **FormatConditions** collection.
 
-You use the **MinPoint** and **MaxPoint** properties of the **DataBar** object to set the values of the shortest bar and longest bar of a range of data. These properties return a **[ConditionValue](Excel.ConditionValue.md)** object, with which you can specify how the thresholds are evaluated.
+You use the **MinPoint** and **MaxPoint** properties of the **Databar** object to set the values of the shortest bar and longest bar of a range of data. These properties return a **[ConditionValue](Excel.ConditionValue.md)** object, with which you can specify how the thresholds are evaluated.
 
-The **DataBar** object also provides properties that enable you to specify an axis line that is displayed when negative values are present, and to specify the color and formatting of data bars.
+The **Databar** object also provides properties that enable you to specify an axis line that is displayed when negative values are present, and to specify the color and formatting of data bars.
 
 
 ## Example
@@ -31,9 +31,9 @@ The **DataBar** object also provides properties that enable you to specify an ax
 The following example creates a range of data, and then applies a data bar to the range. You will notice that because there is an extremely low and high value in the range, the middle values have data bars that are of similar length. To disambiguate the middle values, the sample code uses the **ConditionValue** object to change how the thresholds are evaluated to percentiles.
 
 ```vb
-Sub CreateDataBarCF() 
+Sub CreateDatabarCF() 
  
- Dim cfDataBar As DataBar 
+ Dim cfDatabar As Databar 
  
  ' Create a range of data with a couple of extreme values 
  With ActiveSheet 
@@ -47,14 +47,14 @@ Sub CreateDataBarCF()
  Range("D1:D9").Select 
  
  ' Create a data bar with default behavior 
- Set cfDataBar = Selection.FormatConditions.AddDatabar 
+ Set cfDatabar = Selection.FormatConditions.AddDatabar 
  MsgBox "Because of the extreme values, middle data bars are very similar" 
  
  ' The MinPoint and MaxPoint properties return a ConditionValue object 
  ' which you can use to change threshold parameters 
- cfDataBar.MinPoint.Modify newtype:=xlConditionValuePercentile, _ 
+ cfDatabar.MinPoint.Modify newtype:=xlConditionValuePercentile, _ 
  newvalue:=5 
- cfDataBar.MaxPoint.Modify newtype:=xlConditionValuePercentile, _ 
+ cfDatabar.MaxPoint.Modify newtype:=xlConditionValuePercentile, _ 
  newvalue:=75 
  
 End Sub
@@ -63,35 +63,35 @@ End Sub
 
 ## Methods
 
-- [Delete](Excel.DataBar.Delete.md)
-- [ModifyAppliesToRange](Excel.DataBar.ModifyAppliesToRange.md)
-- [SetFirstPriority](Excel.DataBar.SetFirstPriority.md)
-- [SetLastPriority](Excel.DataBar.SetLastPriority.md)
+- [Delete](Excel.Databar.Delete.md)
+- [ModifyAppliesToRange](Excel.Databar.ModifyAppliesToRange.md)
+- [SetFirstPriority](Excel.Databar.SetFirstPriority.md)
+- [SetLastPriority](Excel.Databar.SetLastPriority.md)
 
 ## Properties
 
-- [Application](Excel.DataBar.Application.md)
-- [AppliesTo](Excel.DataBar.AppliesTo.md)
-- [AxisColor](Excel.DataBar.AxisColor.md)
-- [AxisPosition](Excel.DataBar.AxisPosition.md)
-- [BarBorder](Excel.DataBar.BarBorder.md)
-- [BarColor](Excel.DataBar.BarColor.md)
-- [BarFillType](Excel.DataBar.BarFillType.md)
-- [Creator](Excel.DataBar.Creator.md)
-- [Direction](Excel.DataBar.Direction.md)
-- [Formula](Excel.DataBar.Formula.md)
-- [MaxPoint](Excel.DataBar.MaxPoint.md)
-- [MinPoint](Excel.DataBar.MinPoint.md)
-- [NegativeBarFormat](Excel.DataBar.NegativeBarFormat.md)
-- [Parent](Excel.DataBar.Parent.md)
-- [PercentMax](Excel.DataBar.PercentMax.md)
-- [PercentMin](Excel.DataBar.PercentMin.md)
-- [Priority](Excel.DataBar.Priority.md)
-- [PTCondition](Excel.DataBar.PTCondition.md)
-- [ScopeType](Excel.DataBar.ScopeType.md)
-- [ShowValue](Excel.DataBar.ShowValue.md)
-- [StopIfTrue](Excel.DataBar.StopIfTrue.md)
-- [Type](Excel.DataBar.Type.md)
+- [Application](Excel.Databar.Application.md)
+- [AppliesTo](Excel.Databar.AppliesTo.md)
+- [AxisColor](Excel.Databar.AxisColor.md)
+- [AxisPosition](Excel.Databar.AxisPosition.md)
+- [BarBorder](Excel.Databar.BarBorder.md)
+- [BarColor](Excel.Databar.BarColor.md)
+- [BarFillType](Excel.Databar.BarFillType.md)
+- [Creator](Excel.Databar.Creator.md)
+- [Direction](Excel.Databar.Direction.md)
+- [Formula](Excel.Databar.Formula.md)
+- [MaxPoint](Excel.Databar.MaxPoint.md)
+- [MinPoint](Excel.Databar.MinPoint.md)
+- [NegativeBarFormat](Excel.Databar.NegativeBarFormat.md)
+- [Parent](Excel.Databar.Parent.md)
+- [PercentMax](Excel.Databar.PercentMax.md)
+- [PercentMin](Excel.Databar.PercentMin.md)
+- [Priority](Excel.Databar.Priority.md)
+- [PTCondition](Excel.Databar.PTCondition.md)
+- [ScopeType](Excel.Databar.ScopeType.md)
+- [ShowValue](Excel.Databar.ShowValue.md)
+- [StopIfTrue](Excel.Databar.StopIfTrue.md)
+- [Type](Excel.Databar.Type.md)
 
 ## See also
 

--- a/api/Excel.FormatConditions.AddDatabar.md
+++ b/api/Excel.FormatConditions.AddDatabar.md
@@ -1,5 +1,5 @@
 ---
-title: FormatConditions.AddDataBar method (Excel)
+title: FormatConditions.AddDatabar method (Excel)
 keywords: vbaxl10.chm510080
 f1_keywords:
 - vbaxl10.chm510080
@@ -12,21 +12,21 @@ ms.localizationpriority: medium
 ---
 
 
-# FormatConditions.AddDataBar method (Excel)
+# FormatConditions.AddDatabar method (Excel)
 
-Returns a **[DataBar](Excel.DataBar.md)** object representing a data bar conditional formatting rule for the specified range.
+Returns a **[Databar](Excel.Databar.md)** object representing a data bar conditional formatting rule for the specified range.
 
 
 ## Syntax
 
-_expression_.**AddDataBar**
+_expression_.**AddDatabar**
 
 _expression_ A variable that represents a **[FormatConditions](Excel.FormatConditions.md)** object.
 
 
 ## Return value
 
-**DataBar** object
+**Databar** object
 
 
 ## Remarks


### PR DESCRIPTION
The `Excel.Databar` object is defined with a lower B (not `DataBar`).