### PR TITLE
Invalid Next variable reference in example

### DIFF
--- a/Language/Concepts/Getting-Started/using-for-eachnext-statements.md
+++ b/Language/Concepts/Getting-Started/using-for-eachnext-statements.md
@@ -60,7 +60,7 @@ Sub TestForNumbers()
    MsgBox "Cell " & rng.Address & " contains a non-numeric value." 
    Exit For 
   End If 
- Next c 
+ Next rng 
 End Sub
 ```
 


### PR DESCRIPTION
Fixes a small error I noticed in a code example where the Next variable is incorrectly referenced 🙂