### PR TITLE
To show users about Borders object when applied over a range of cells

### DIFF
--- a/api/Excel.Borders.md
+++ b/api/Excel.Borders.md
@@ -19,7 +19,7 @@ A collection of four **[Border](Excel.Border(object).md)** objects that represen
 
 ## Remarks
 
-Use the **Borders** property to return the **Borders** collection, which contains all four borders.
+Use the **Borders** property to return the **Borders** collection, which contains all four borders when used with a single cell. But if **Borders** property is used on a range object then **Borders** property returns **Borders** collection, which contains all four borders of a cell , plus **xlInsideHorizontal** and **xlInsideVertical** i.e. it sets inside as well as outside borders of a range selection.
 
 You can set border properties for an individual border only with **Range** and **Style** objects. Other bordered objects, such as error bars and series lines, have a border that's treated as a single entity, regardless of how many sides it has. For these objects, you must return and set properties for the entire border as a unit. For more information, see the **Border** object.
 
@@ -30,6 +30,12 @@ The following example adds a double border to cell A1 on worksheet one.
 
 ```vb
 Worksheets(1).Range("A1").Borders.LineStyle = xlDouble
+```
+
+The following example adds a double border on the inside as well as outside to a range selection from A1 to C3 on worksheet one.
+
+```vb
+Worksheets(1).Range("A1:C3").Borders.LineStyle = xlDouble
 ```
 
 Use **Borders** (_index_), where _index_ identifies the border, to return a single **Border** object. The following example sets the color of the bottom border of cells A1:G1 to red.

--- a/api/Excel.Borders.md
+++ b/api/Excel.Borders.md
@@ -19,7 +19,7 @@ A collection of four **[Border](Excel.Border(object).md)** objects that represen
 
 ## Remarks
 
-Use the **Borders** property to return the **Borders** collection, which contains all four borders when used with a single cell. But if **Borders** property is used on a range object then **Borders** property returns **Borders** collection, which contains all four borders of a cell , plus **xlInsideHorizontal** and **xlInsideVertical** i.e. it sets inside as well as outside borders of a range selection.
+Use the **Borders** property to return the **Borders** collection, which contains all four borders. You can apply different borders to each side of a cell or range. For more information how to apply borders to a range of cells, see **[Range.Borders](Excel.Range.Borders.md)** property.
 
 You can set border properties for an individual border only with **Range** and **Style** objects. Other bordered objects, such as error bars and series lines, have a border that's treated as a single entity, regardless of how many sides it has. For these objects, you must return and set properties for the entire border as a unit. For more information, see the **Border** object.
 


### PR DESCRIPTION
The original issue shows the use of Borders object over a cell. It was left to users to find out on their own how Borders behave with the range of cells. This can be pretty confusing to new learners. I tried to see how it behaves with the range of cells. The output was not what i predicted. I thought Borders object will print borders only on the outside of the range of cells since its mentioned that "Use the Borders property to return the Borders collection, which contains all four borders" in the Remarks section. Those four borders are : xlEdgeBottom, xlEdgeLeft, xlEdgeRight, xlEdgeTop. But what i saw was it applied borders on the inside as well using xlInsideHorizontal and xlInsideVertical. So it returned 6 borders. 

So if we show how Borders applies to a range of cells, then new learners do not have to assume anything. It will make this article more clear and complete.