### PR TITLE
Fields.Update: Mention bug at least for Word 2016

### DIFF
--- a/api/Word.Fields.Update.md
+++ b/api/Word.Fields.Update.md
@@ -33,6 +33,7 @@ Long
 
 Returns 0 (zero) if no errors occur when the fields are updated, or returns a **Long** that represents the index of the first field that contains an error.
 
+Remark: When using this with Word 2016 and possibly with others, the number may be incorrect.
 
 ## Example
 


### PR DESCRIPTION
Word 2016, Version 2211 (Build 15831.20208 Klick-und-Los) Steps to reproduce:
* Open new Document.
* Add two fields with Ctrl-F9
* Set fields to { IF a = b c d } and { DOCPROPERTY "notexist" } in any order
* MsgBox ActiveDocument.Fields.Update => "1", no matter what is the order of the fields