### PR TITLE
Fix breadcrumbs

### DIFF
--- a/breadcrumb/toc.yml
+++ b/breadcrumb/toc.yml
@@ -1,3 +1,31 @@
-- name: VBA-Docs
-  tocHref: /
-  topicHref: /
+- name: VBA
+  tocHref: /office/vba/
+  topicHref: /office/vba/
+  items:
+  - name: Access
+    tocHref: /office/vba/api/overview/access/
+    topicHref: /office/vba/api/overview/access/
+  - name: Excel
+    tocHref: /office/vba/api/overview/excel/
+    topicHref: /office/vba/api/overview/excel/
+  - name: Office for Mac
+    tocHref: /office/vba/api/overview/office-mac/
+    topicHref: /office/vba/api/overview/office-mac/
+  - name: Outlook
+    tocHref: /office/vba/api/overview/outlook/
+    topicHref: /office/vba/api/overview/outlook/
+  - name: PowerPoint
+    tocHref: /office/vba/api/overview/powerpoint/
+    topicHref: /office/vba/api/overview/powerpoint/
+  - name: Project
+    tocHref: /office/vba/api/overview/project/
+    topicHref: /office/vba/api/overview/project/
+  - name: Publisher
+    tocHref: /office/vba/api/overview/publisher/
+    topicHref: /office/vba/api/overview/publisher/
+  - name: Visio
+    tocHref: /office/vba/api/overview/visio/
+    topicHref: /office/vba/api/overview/visio/
+  - name: Word
+    tocHref: /office/vba/api/overview/word/
+    topicHref: /office/vba/api/overview/word/

--- a/docfx.json
+++ b/docfx.json
@@ -38,7 +38,6 @@
     "globalMetadata": {
       "uhfHeaderId": "MSDocsHeader-VBA",
       "breadcrumb_path": "/breadcrumb/toc.json",
-      "extendBreadcrumb": true,
       "ms.suite": "office",
       "ms.technology": "vba",
       "ms.author": "o365devx",

--- a/docfx.json
+++ b/docfx.json
@@ -37,7 +37,7 @@
     "externalReference": [],
     "globalMetadata": {
       "uhfHeaderId": "MSDocsHeader-VBA",
-      "breadcrumb_path": "office/vba/breadcrumb/toc.json",
+      "breadcrumb_path": "/office/vba/breadcrumb/toc.json",
       "ms.suite": "office",
       "ms.technology": "vba",
       "ms.author": "o365devx",

--- a/docfx.json
+++ b/docfx.json
@@ -37,7 +37,7 @@
     "externalReference": [],
     "globalMetadata": {
       "uhfHeaderId": "MSDocsHeader-VBA",
-      "breadcrumb_path": "/breadcrumb/toc.json",
+      "breadcrumb_path": "office/vba/breadcrumb/toc.json",
       "ms.suite": "office",
       "ms.technology": "vba",
       "ms.author": "o365devx",


### PR DESCRIPTION
This PR brings breadcrumb implementation into compliance with current guidelines. I've expanded the breadcrumb file to specify the product nodes of the TOC, and removed the 'extend breadcrumb' feature from the docfx file, as the auto-extension of breadcrumbs is no longer supported. For more information about current breadcrumb guidelines please see https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main