### PR TITLE
Bug 7607095: [EXTERNAL] PictureType Property doesn't document 'Shared…

### DIFF
--- a/api/Access.CommandButton.PictureType.md
+++ b/api/Access.CommandButton.PictureType.md
@@ -28,11 +28,11 @@ _expression_ A variable that represents a **[CommandButton](Access.CommandButton
 
 The **PictureType** property uses the following settings.
 
-|Setting|Description|
-|:-----|:-----|
-|0|(Default) The picture is embedded in the object and becomes part of the database file.|
-|1|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture on the disk.|
-|2|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture within the database.|
+|Setting|Value|Meaning|
+|:-----|:-----|:-----|
+|Embedded (Default)|0|The picture is embedded in the object and becomes part of the database file.|
+|Linked|1|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture on the disk.|
+|Shared|2|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture within the database.|
 
 This property can be set only in form Design view or report Design view.
 

--- a/api/Access.Form.PictureType.md
+++ b/api/Access.Form.PictureType.md
@@ -28,16 +28,17 @@ _expression_ A variable that represents a **[Form](Access.Form.md)** object.
 
 The **PictureType** property uses the following settings.
 
-|Setting|Description|
-|:-----|:-----|
-|0|(Default) The picture is embedded in the object and becomes part of the database file.|
-|1|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture on the disk.|
+|Setting|Value|Meaning|
+|:-----|:-----|:-----|
+|Embedded (Default)|0|The picture is embedded in the object and becomes part of the database file.|
+|Linked|1|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture on the disk.|
+|Shared|2|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture within the database.|
 
 This property can be set only in form Design view or report Design view.
 
 For controls, you can set the default for this property by using the default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 
-When this property is set to 0, the size of the database increases by the size of the picture file and, with some .wmf files, the size may increase as much as twice the size of the picture file. When this property is set to 1, there is no increase in the size of the database because Microsoft Access only saves a pointer to the picture's location on the disk.
+When this property is set to 0, the size of the database increases by the size of the picture file and, with some .wmf files, the size may increase as much as twice the size of the picture file. When this property is set to 1, there is no increase in the size of the database because Microsoft Access only saves a pointer to the picture's location on the disk. When this property is set to 2, the database size will increase for the first control that uses the picture, but will not increase if additional controls use the picture with this property value.
 
 > [!NOTE] 
 > If a linked file is moved to another location on the disk, you must re-establish the link by using the object's **Picture** property.

--- a/api/Access.Image.PictureType.md
+++ b/api/Access.Image.PictureType.md
@@ -28,16 +28,18 @@ _expression_ A variable that represents an **[Image](Access.Image.md)** object.
 
 The **PictureType** property uses the following settings.
 
-|Setting|Description|
-|:-----|:-----|
-|0|(Default) The picture is embedded in the object and becomes part of the database file.|
-|1|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture on the disk.|
+|Setting|Value|Meaning|
+|:-----|:-----|:-----|
+|Embedded (Default)|0|The picture is embedded in the object and becomes part of the database file.|
+|Linked|1|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture on the disk.|
+|Shared|2|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture within the database.|
+
 
 This property can be set only in form Design view or report Design view.
 
 For controls, you can set the default for this property by using the default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 
-When this property is set to 0, the size of the database increases by the size of the picture file and, with some .wmf files, the size may increase as much as twice the size of the picture file. When this property is set to 1, there is no increase in the size of the database because Microsoft Access only saves a pointer to the picture's location on the disk.
+When this property is set to 0, the size of the database increases by the size of the picture file and, with some .wmf files, the size may increase as much as twice the size of the picture file. When this property is set to 1, there is no increase in the size of the database because Microsoft Access only saves a pointer to the picture's location on the disk. When this property is set to 2, the database size will increase for the first control that uses the picture, but will not increase if additional controls use the picture with this property value.
 
 > [!NOTE] 
 > If a linked file is moved to another location on the disk, you must re-establish the link by using the object's **Picture** property.

--- a/api/Access.NavigationButton.PictureType.md
+++ b/api/Access.NavigationButton.PictureType.md
@@ -28,16 +28,17 @@ _expression_ A variable that represents a **[NavigationButton](Access.Navigation
 
 The **PictureType** property uses the following settings.
 
-|Setting|Description|
-|:-----|:-----|
-|0|(Default) The picture is embedded in the object and becomes part of the database file.|
-|1|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture on the disk.|
+|Setting|Value|Meaning|
+|:-----|:-----|:-----|
+|Embedded (Default)|0|The picture is embedded in the object and becomes part of the database file.|
+|Linked|1|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture on the disk.|
+|Shared|2|The picture is linked to the object. Microsoft Access stores a pointer to the location of the picture within the database.|
 
 This property can be set only in form Design view or report Design view.
 
 For controls, you can set the default for this property by using the default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 
-When this property is set to 0, the size of the database increases by the size of the picture file and, with some .wmf files, the size may increase as much as twice the size of the picture file. When this property is set to 1, there is no increase in the size of the database because Microsoft Access only saves a pointer to the picture's location on the disk.
+When this property is set to 0, the size of the database increases by the size of the picture file and, with some .wmf files, the size may increase as much as twice the size of the picture file. When this property is set to 1, there is no increase in the size of the database because Microsoft Access only saves a pointer to the picture's location on the disk. When this property is set to 2, the database size will increase for the first control that uses the picture, but will not increase if additional controls use the picture with this property value.
 
 > [!NOTE] 
 > If a linked file is moved to another location on the disk, you must re-establish the link by using the object's **Picture** property.


### PR DESCRIPTION
…' setting

Update docs to include Shared property and also to more explicity clarify what the setting enums stand for