### PR TITLE
Tab control doesn't support MultiRow property when UseTheme=Yes

### DIFF
--- a/api/Access.TabControl.MultiRow.md
+++ b/api/Access.TabControl.MultiRow.md
@@ -39,6 +39,8 @@ When the **MultiRow** property is set to **True**, the number of rows is determi
 
 When the **MultiRow** property is set to **False** and the width of the tabs exceeds the width of the control, navigation buttons appear on the right side of the tab control. Use the navigation buttons to scroll through all the tabs on the tab control.
 
+> [!NOTE] 
+> The **MultiRow** property is not supported when the **[UseTheme](Access.TabControl.UseTheme.md)** property it set to "Yes."
 
 ## Example
 


### PR DESCRIPTION
Cite in article that the multirow property is not supported when the UseTheme property is set to Yes