### PR TITLE
Update Word.Find.MatchWildcards.md

### DIFF
--- a/api/Word.Find.MatchWildcards.md
+++ b/api/Word.Find.MatchWildcards.md
@@ -38,7 +38,7 @@ This example finds and selects the next three-letter word that begins with "s" a
 ```vb
 With Selection.Find 
  .ClearFormatting 
- .Text = "s*t" 
+ .Text = "s?t" 
  .MatchAllWordForms = False 
  .MatchSoundsLike = False 
  .MatchFuzzy = False 


### PR DESCRIPTION
*"This example finds and selects the next three-letter word that begins with "s" and ends with "t."* then the wildcard used should be "?" not "*".