### PR TITLE
Put Word.ContentControlListEntry and Word.ContentControl at correct outline level.

### DIFF
--- a/api/TOC.md
+++ b/api/TOC.md
@@ -28938,7 +28938,7 @@
 ###### [Count](Word.ContentControlListEntries.Count.md)
 ###### [Creator](Word.ContentControlListEntries.Creator.md)
 ###### [Parent](Word.ContentControlListEntries.Parent.md)
-##### [ContentControlListEntry object](Word.ContentControlListEntry.md)
+#### [ContentControlListEntry object](Word.ContentControlListEntry.md)
 ##### Methods
 ###### [Delete](Word.ContentControlListEntry.Delete.md)
 ###### [MoveDown](Word.ContentControlListEntry.MoveDown.md)
@@ -28951,7 +28951,7 @@
 ###### [Parent](Word.ContentControlListEntry.Parent.md)
 ###### [Text](Word.ContentControlListEntry.Text.md)
 ###### [Value](Word.ContentControlListEntry.Value.md)
-##### [ContentControls object](Word.ContentControls.md)
+#### [ContentControls object](Word.ContentControls.md)
 ##### Methods
 ###### [Add](Word.ContentControls.Add.md)
 ###### [Item](Word.ContentControls.Item.md)


### PR DESCRIPTION
I believe these two changed headings need to be on outline level 4 like all the other object documentation headings. They were on outline level 5, which put them on the same level as the Methods and Properties of the the previous object (ContentControlListEntry). I believe this is incorrect:
<img width="326" alt="Screen Shot 2023-06-30 at 3 42 07 PM" src="https://github.com/MicrosoftDocs/VBA-Docs/assets/41761990/31baca05-e3d5-4d49-9d9a-82ef17ef79c6">

This PR fixes the outline levels to be on outline level 4, not 5.