### PR TITLE
Update getfile-method.md

### DIFF
--- a/Language/Reference/User-Interface-Help/getfile-method.md
+++ b/Language/Reference/User-Interface-Help/getfile-method.md
@@ -29,7 +29,7 @@ The **GetFile** method syntax has these parts:
 
 ## Remarks
 
-An error occurs if the specified file does not exist.
+An error occurs if the specified file does not exist or if _filespec_ is an HTTP-based path.
 
 ## See also
 


### PR DESCRIPTION
Added additional error condition for files stored in OneDrive/SharePoint where the provided file path is an HTTP path. Not sure if this the optimal wording or not.