### PR TITLE
Update PowerPoint.shapes.addinkshapefromxml.md

### DIFF
--- a/api/PowerPoint.shapes.addinkshapefromxml.md
+++ b/api/PowerPoint.shapes.addinkshapefromxml.md
@@ -12,7 +12,7 @@ Creates an ink shape. Returns a [Shape](PowerPoint.Shape.md) object that represe
 
 ## Syntax
 
-_expression_. `AddInkShapeFromXML`( _InkXML_, _InkXML_, _Left_, _Top_, _Width_, _Height_)
+_expression_. `AddInkShapeFromXML`( _InkXML_, _Left_, _Top_, [_Width_], [_Height_])
 
 _expression_ A variable that represents a **[Shapes](PowerPoint.Shapes.md)** object.
 


### PR DESCRIPTION
The InkXML argument was duplicated and the last two arguments are optional.

It would be good to add an example but I can't get this method to work, which makes me wonder if it relates to legacy msoInk via Pens vs. msoInkComment via Draw.