### PR TITLE
Remove PpDateTimeFormat enumeration table and add link to enum

### DIFF
--- a/api/PowerPoint.TextRange.InsertDateTime.md
+++ b/api/PowerPoint.TextRange.InsertDateTime.md
@@ -40,25 +40,8 @@ TextRange
 
 ## Remarks
 
-The  _DateTimeFormat_ parameter value can be one of these **PpDateTimeFormat** constants.
+The  _DateTimeFormat_ parameter value can be one of these **[PpDateTimeFormat](https://learn.microsoft.com/en-us/office/vba/api/powerpoint.ppdatetimeformat)** constants.
 
-
-||
-|:-----|
-|**ppDateTimeddddMMMMddyyyy**|
-|**ppDateTimedMMMMyyyy**|
-|**ppDateTimedMMMyy**|
-|**ppDateTimeFormatMixed**|
-|**ppDateTimeHmm**|
-|**ppDateTimehmmAMPM**|
-|**ppDateTimeHmmss**|
-|**ppDateTimehmmssAMPM**|
-|**ppDateTimeMdyy**|
-|**ppDateTimeMMddyyHmm**|
-|**ppDateTimeMMddyyhmmAMPM**|
-|**ppDateTimeMMMMdyyyy**|
-|**ppDateTimeMMMMyy**|
-|**ppDateTimeMMyy**|
 
 The  _InsertAsField_ parameter value can be one of these **MsoTriState** constants.
 

--- a/api/PowerPoint.TextRange.InsertDateTime.md
+++ b/api/PowerPoint.TextRange.InsertDateTime.md
@@ -40,7 +40,7 @@ TextRange
 
 ## Remarks
 
-The  _DateTimeFormat_ parameter value can be one of these **[PpDateTimeFormat](https://learn.microsoft.com/en-us/office/vba/api/powerpoint.ppdatetimeformat)** constants.
+The _DateTimeFormat_ parameter value can be one of these **[PpDateTimeFormat](https://learn.microsoft.com/office/vba/api/powerpoint.ppdatetimeformat)** constants.
 
 
 The  _InsertAsField_ parameter value can be one of these **MsoTriState** constants.


### PR DESCRIPTION
The table for the PpDateTimeFormat enumeration is not up to date and it also doesn't match the separate page for that enumeration. Suggest deleting it from here and linking to the enumeration page, which I will also raise a PR for.