### PR TITLE
Update Excel.Range.CopyFromRecordset.md

### DIFF
--- a/api/Excel.Range.CopyFromRecordset.md
+++ b/api/Excel.Range.CopyFromRecordset.md
@@ -40,6 +40,7 @@ Long
 ## Remarks
 
 Copying begins at the current row of the **Recordset** object. After copying is completed, the **EOF** property of the **Recordset** object is **True**.
+It is recommended that you set an object variable to the range to which you are copying from the recordset.  Failing to do so may cause generic automation errors depending on the recordset and the range.
 
 
 ## Example
@@ -51,8 +52,9 @@ For iCols = 0 to rs.Fields.Count - 1
  ws.Cells(1, iCols + 1).Value = rs.Fields(iCols).Name 
 Next 
 ws.Range(ws.Cells(1, 1), _ 
- ws.Cells(1, rs.Fields.Count)).Font.Bold = True 
-ws.Range("A2").CopyFromRecordset rs
+ ws.Cells(1, rs.Fields.Count)).Font.Bold = True
+Set PushRange = ws.Range("A2")
+PushRange.CopyFromRecordset rs
 ```
 
 

--- a/api/Excel.Range.CopyFromRecordset.md
+++ b/api/Excel.Range.CopyFromRecordset.md
@@ -40,7 +40,7 @@ Long
 ## Remarks
 
 Copying begins at the current row of the **Recordset** object. After copying is completed, the **EOF** property of the **Recordset** object is **True**.
-It is recommended that you set an object variable to the range to which you are copying from the recordset.  Failing to do so may cause generic automation errors depending on the recordset and the range.
+It's recommended that you set an object variable to the range to which you are copying from the recordset.  Failing to do so may cause generic automation errors depending on the recordset and the range.
 
 
 ## Example


### PR DESCRIPTION
Added language and edited the example to demonstrate the recommended practice of setting an object variable equal to the range to which you want to copy.