### PR TITLE
[METADATA UPDATE][Merge by 2024-01-26] Retiring the ms.prod and ms.technology metadata attributes from the Learn platform (values moving to ms.service)

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -39,7 +39,6 @@
       "uhfHeaderId": "MSDocsHeader-VBA",
       "breadcrumb_path": "/office/vba/breadcrumb/toc.json",
       "ms.suite": "office",
-      "ms.technology": "vba",
       "ms.author": "o365devx",
       "author": "o365devx",
       "description": "Office VBA reference topic",
@@ -47,10 +46,6 @@
       "feedback_system": "Standard"
     },
     "fileMetadata": {
-      "ms.service": {
-        "api/PowerPoint.*.md": "powerpoint",
-        "powerpoint/**.md": "powerpoint"
-      },
       "ms.topic": {
         "api/**.md": "reference",
         "access/**.md": "conceptual",
@@ -65,7 +60,9 @@
         "visio/**.md": "conceptual",
         "word/**.md": "conceptual"
       },
-      "ms.prod": {
+      "ms.service": {
+        "api/PowerPoint.*.md": "powerpoint",
+        "powerpoint/**.md": "powerpoint",
         "api/Access.*.md": "access",
         "api/Excel.*.md": "excel",
         "api/Outlook.*.md": "outlook",
@@ -85,6 +82,29 @@
         "publisher/**.md": "publisher",
         "visio/**.md": "visio",
         "word/**.md": "word"
+      },
+      "ms.subservice": {
+        "api/PowerPoint.*.md": "vba",
+        "powerpoint/**.md": "vba",
+        "api/Access.*.md": "vba",
+        "api/Excel.*.md": "vba",
+        "api/Outlook.*.md": "vba",
+        "api/Project.*.md": "vba",
+        "api/Publisher.*.md": "vba",
+        "api/Visio.*.md": "vba",
+        "api/Word.*.md": "vba",
+        "api/Office.*.md": "vba",
+        "api/overview/**.md": "vba",
+        "access/**.md": "vba",
+        "excel/**.md": "vba",
+        "Language/**.md": "vba",
+        "Library-Reference/**.md": "vba",
+        "Office-Mac/**.md": "vba",
+        "outlook/**.md": "vba",
+        "project/**.md": "vba",
+        "publisher/**.md": "vba",
+        "visio/**.md": "vba",
+        "word/**.md": "vba"
       },
       "ROBOTS": {
          "access/Concepts/Miscellaneous/**.md": "NOINDEX,NOFOLLOW",


### PR DESCRIPTION
A Pull Request has been made from the Learn Platform's Metadata Management System. Please review and merge this Pull Request within 5 days. If you have any questions or concerns about the purpose of these metadata updates, please contact [docs-allowlist-mgmt@microsoft.com](mailto:docs-allowlist-mgmt@microsoft.com). If you are not the correct contact for this content and repository, please notify [Metadata-Management@microsoft.com](mailto:Metadata-Management@microsoft.com).

If this Pull Request is not merged within 14 days, it will be automatically merged by our system to ensure the timeliness of the metadata update. This includes bypassing the Repository's Branch Policy, including if Review Required is enabled. Please notify [Metadata-Management@microsoft.com](mailto:Metadata-Management@microsoft.com) if you have questions or concerns or would like Pull Requests for metadata updates to merge automatically in future.


Summary
In Germanium, we will be retiring the ms.prod and ms.technology metadata attributes from the Learn platform and consolidating values into ms.service and ms.subservice for reporting on content by product.

C+E Skilling Content Architecture manages internal, business-facing taxonomies that enable reporting on key metrics for content published on Microsoft Learn. Authors manually apply values from these taxonomies to populate metadata attributes.
Two of these taxonomies are ms.prod/ms.technology and ms.service/ms.subservice. "ms.prod" and "ms.service" were distinctions carried over from legacy systems that predated the Learn platform, intended to differentiate on-prem products from cloud services.
In Germanium, we will retire ms.prod/ms.technology and migrate metadata to the ms.service/ms.subservice attributes. We plan to rename the attributes from ms.service and ms.subservice in a future semester.
Why are we making this change?

For the business: Accuracy of reporting metadata directly impacts the accuracy of content analytics, so it's important that related taxonomies reflect the current state of the business. Most product taxonomies within Microsoft no longer distinguish between "on-prem" and "cloud service."
For content authors: We eliminate the need to choose between two similar attributes when applying reporting metadata to content or filtering reports.
For engineers, data scientists, and taxonomists: Simplifying and reducing underlying metadata attributes reduces the cost and complexity required to extend metadata capabilities on the platform.
Frequently Asked Questions
Why does this Pull Request appear to be made by the Repository Owner? We open Pull Requests two different ways.

For Git Repos with a permissioned Service Account, we open the PR from our Document Build Service Account.
For Git Repos that we either do not have Service Account permission for or the repo is in Azure Repos (ADO) we open the Pull Requests in an automated way with the PR creator as the Repo owner.
How can I revert a Pull Request that has been merged and created an unexpected issue? Whether a PR has been merged manually or automatically, you can revert it if an issue arises. See [Reverting a pull request - GitHub Docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/reverting-a-pull-request).