### PR TITLE
Update work-with-shapes-drawing-objects.md

### DIFF
--- a/powerpoint/How-to/work-with-shapes-drawing-objects.md
+++ b/powerpoint/How-to/work-with-shapes-drawing-objects.md
@@ -70,7 +70,7 @@ The preceding guidelines also apply when you are setting properties of shapes th
 
 ## Looping through a Shapes or ShapeRange collection
 
-Even if you cannot perform an operation on several shapes in the user interface at the same time by selecting them and then using a command, you can perform the equivalent action programmatically by looping through the **Shapes** collection or through a **ShapeRange** collection that contains the shapes you want to work with, and applying the appropriate properties and methods to the individual **Shape** objects in the collection. The following example loops through all the shapes on `myDocument` and adds text to each shape that is an AutoShape. and adds text to each shape that is an AutoShape. 
+Even if you cannot perform an operation on several shapes in the user interface at the same time by selecting them and then using a command, you can perform the equivalent action programmatically by looping through the **Shapes** collection or through a **ShapeRange** collection that contains the shapes you want to work with, and applying the appropriate properties and methods to the individual **Shape** objects in the collection. The following example loops through all the shapes on `myDocument` and adds text to each shape that is an AutoShape. 
 ```vb
 Set myDocument = ActivePresentation.Slides(1) 
 For Each sh In myDocument.Shapes 


### PR DESCRIPTION
Corrected a typographical error in the article where the sentence fragment "and adds text to each shape that is an AutoShape." was repeated so that the text appeared (verbatim) like so:

"... and adds text to each shape that is an AutoShape. and adds text to each shape that is an AutoShape."

As shown above, rather than ending with a period, the paragraph in the article ended with a redundant string of text identical to the latter segment of the sentence immediately preceding it.  This was quite obviously included inadvertently.