### PR TITLE
Changed Visio.Characters.ParaProps access scope

### DIFF
--- a/api/Visio.Characters.ParaProps.md
+++ b/api/Visio.Characters.ParaProps.md
@@ -13,7 +13,7 @@ ms.localizationpriority: medium
 
 # Characters.ParaProps property (Visio)
 
-Sets the paragraph property of a **Characters** object to a new value. Read/write.
+Sets the paragraph property of a **Characters** object to a new value. Write-only.
 
 
 ## Syntax


### PR DESCRIPTION
@lindalu-MSFT Set access scope for Visio.Characters.ParaProps to Write-only.  (This is in line with CharProps which is also/already write-only).