### PR TITLE
Change "ByVal Cancel.." to "Cancel.." in BeforeDoubleClick and BeforeRightClick example code

### DIFF
--- a/api/Excel.Workbook.SheetBeforeDoubleClick.md
+++ b/api/Excel.Workbook.SheetBeforeDoubleClick.md
@@ -42,7 +42,7 @@ This example disables the default double-click action.
 
 ```vb
 Private Sub Workbook_SheetBeforeDoubleClick(ByVal Sh As Object, _ 
- ByVal Target As Range, ByVal Cancel As Boolean) 
+ ByVal Target As Range, Cancel As Boolean) 
  Cancel = True 
 End Sub
 ```

--- a/api/Excel.Workbook.SheetBeforeRightClick.md
+++ b/api/Excel.Workbook.SheetBeforeRightClick.md
@@ -42,7 +42,7 @@ This example disables the default right-click action.
 
 ```vb
 Private Sub Workbook_SheetBeforeRightClick(ByVal Sh As Object, _ 
- ByVal Target As Range, ByVal Cancel As Boolean) 
+ ByVal Target As Range, Cancel As Boolean) 
  Cancel = True 
 End Sub
 ```

--- a/api/PowerPoint.Application.WindowBeforeDoubleClick.md
+++ b/api/PowerPoint.Application.WindowBeforeDoubleClick.md
@@ -53,7 +53,7 @@ In slide sorter view, the default double-click event for any slide is to change 
 
 
 ```vb
-Private Sub App_WindowBeforeDoubleClick (ByVal Sel As Selection, ByVal Cancel As Boolean)
+Private Sub App_WindowBeforeDoubleClick (ByVal Sel As Selection, Cancel As Boolean)
 
     With Application.ActiveWindow
 

--- a/api/PowerPoint.Application.WindowBeforeRightClick.md
+++ b/api/PowerPoint.Application.WindowBeforeRightClick.md
@@ -38,7 +38,7 @@ This example creates a duplicate of the selected shape. If the shape has a text 
 
 
 ```vb
-Private Sub App_WindowBeforeRightClick(ByVal Sel As Selection, ByVal Cancel As Boolean)
+Private Sub App_WindowBeforeRightClick(ByVal Sel As Selection, Cancel As Boolean)
 
     With ActivePresentation.Selection.ShapeRange
 


### PR DESCRIPTION
## Changes
- Changed "ByVal Cancel As Boolean" to "Cancel As Boolean" in example code in the following files:
    - Excel.Workbook.SheetBeforeDoubleClick
    - Excel.Workbook.SheetBeforeRightClick
    - Powerpoint.Application.WindowBeforeDoubleClick
    - Powerpoint.Application.WindowBeforeRightClick

Passing the "Cancel" parameter by value results in an error.
All other event pages omit the "ByVal" when declaring the parameter. Example: [Worksheet.BeforeRightClick](https://learn.microsoft.com/en-gb/office/vba/api/excel.worksheet.beforerightclick), [Workbook.BeforeClose](https://learn.microsoft.com/en-gb/office/vba/api/excel.workbook.beforeclose), [Workbook.BeforeSave](https://learn.microsoft.com/en-gb/office/vba/api/excel.workbook.beforesave), [MailItem.BeforeDelete](https://learn.microsoft.com/en-gb/office/vba/api/outlook.mailitem.beforedelete), etc..