### PR TITLE
Update PowerPoint.View.PasteSpecial.md to include SVG

### DIFF
--- a/api/PowerPoint.View.PasteSpecial.md
+++ b/api/PowerPoint.View.PasteSpecial.md
@@ -56,6 +56,7 @@ The DataType parameter can be one of these **PpPasteDataType** constants
 |**ppPastePNG**|
 |**ppPasteRTF**|
 |**ppPasteShape**|
+|**ppPasteSVG**|
 |**ppPasteText**|
 
 The DisplayAsIcon parameter can be one of these **MsoTriState** constants.


### PR DESCRIPTION
Added the enum constant name for pasting as SVG, which has been available since at least Office 2016 IIRC.