### PR TITLE
Create Outlook.Folder.GetOwner

### DIFF
--- a/Outlook.Folder.GetOwner
+++ b/Outlook.Folder.GetOwner
@@ -1,0 +1,38 @@
+---
+title: Folder.GetOwner method (Outlook)
+
+// how to do comments?? I'm not sure about this block
+keywords: vbaol11.chm3556
+f1_keywords:
+- vbaol11.chm3556
+api_name:
+- Outlook.Folder.GetOrganizer
+ms.assetid: ??
+ms.date: 05/02/2024
+ms.localizationpriority: medium
+---
+
+
+# Folder.GetOwner method (Outlook)
+
+Obtains the **[AddressEntry](Outlook.AddressEntry.md)** object that contains information from the Address Book about the owner of the **[Folder](Outlook.Folder.md)**.
+
+
+## Syntax
+
+_expression_. `GetOwner`
+
+_expression_ A variable that represents a [Folder](Outlook.Folder.md) object.
+
+
+## Return value
+
+An **AddressEntry** object that represents the owner of the **Folder**.
+
+
+## See also
+
+
+[Folder Object](Outlook.Folder.md)
+
+[!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/Outlook.Folder.GetOwner
+++ b/Outlook.Folder.GetOwner
@@ -6,7 +6,7 @@ f1_keywords:
 - vbaol11.chm3556
 api_name:
 - Outlook.Folder.GetOrganizer
-ms.assetid: ??
+ms.assetid: e728cef8-170f-4286-bf3b-6a1acad6cc22
 ms.date: 05/02/2024
 ms.localizationpriority: medium
 ---

--- a/Outlook.Folder.GetOwner
+++ b/Outlook.Folder.GetOwner
@@ -1,7 +1,6 @@
 ---
 title: Folder.GetOwner method (Outlook)
 
-// how to do comments?? I'm not sure about this block
 keywords: vbaol11.chm3556
 f1_keywords:
 - vbaol11.chm3556


### PR DESCRIPTION
Creating a page for the new Folder.GetOwner method available in the April 2024 fork of Office for Outlook Desktop. I think this is complete except perhaps the keywords, f1_keywords, and ms_assetid fields. I'm not sure how those work.