### PR TITLE
Update case of "Object"

### DIFF
--- a/api/Excel.CategoryCollection.Parent.md
+++ b/api/Excel.CategoryCollection.Parent.md
@@ -30,7 +30,7 @@ This property will return the **Chart** object that owns this collection of cate
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.chart.fullseriescollection.md
+++ b/api/Excel.chart.fullseriescollection.md
@@ -28,7 +28,7 @@ _expression_ A variable that represents a **[Chart](Excel.Chart(object).md)** ob
 
 ## Return value
 
-**OBJECT**
+**Object**
 
 
 ## Remarks

--- a/api/Excel.chartcategory.parent.md
+++ b/api/Excel.chartcategory.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ChartCategory](Excel.chartcategory.
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.chartgroup.categorycollection.md
+++ b/api/Excel.chartgroup.categorycollection.md
@@ -30,7 +30,7 @@ _expression_ A variable that represents a **[ChartGroup](Excel.ChartGroup(object
 
 ## Return value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.chartgroup.fullcategorycollection.md
+++ b/api/Excel.chartgroup.fullcategorycollection.md
@@ -29,7 +29,7 @@ _expression_ A variable that represents a **[ChartGroup](Excel.ChartGroup(object
 
 ## Return value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.datafeedconnection.parent.md
+++ b/api/Excel.datafeedconnection.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[DataFeedConnection](Excel.datafeedc
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.fullseriescollection.parent.md
+++ b/api/Excel.fullseriescollection.parent.md
@@ -28,7 +28,7 @@ Typically the chart to which this **FullSeriesCollection** object belongs is ret
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.model.parent.md
+++ b/api/Excel.model.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[Model](Excel.Model.md)** object.
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modelchanges.parent.md
+++ b/api/Excel.modelchanges.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelChanges](Excel.modelchanges.md
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modelcolumnchange.parent.md
+++ b/api/Excel.modelcolumnchange.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelColumnChange](Excel.modelcolum
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modelcolumnchanges.parent.md
+++ b/api/Excel.modelcolumnchanges.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelColumnChanges](Excel.modelcolu
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modelcolumnname.parent.md
+++ b/api/Excel.modelcolumnname.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelColumnName](Excel.modelcolumnn
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modelcolumnnames.parent.md
+++ b/api/Excel.modelcolumnnames.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelColumnNames](Excel.modelcolumn
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modelconnection.adoconnection.md
+++ b/api/Excel.modelconnection.adoconnection.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelConnection](Excel.modelconnect
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modelconnection.parent.md
+++ b/api/Excel.modelconnection.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelConnection](Excel.modelconnect
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modelmeasurename.parent.md
+++ b/api/Excel.modelmeasurename.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelMeasureName](Excel.modelmeasur
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modelmeasurenames.parent.md
+++ b/api/Excel.modelmeasurenames.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelMeasureNames](Excel.modelmeasu
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modelrelationship.parent.md
+++ b/api/Excel.modelrelationship.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelRelationship](Excel.modelrelat
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modelrelationships.parent.md
+++ b/api/Excel.modelrelationships.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelRelationships](Excel.modelrela
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modeltable.parent.md
+++ b/api/Excel.modeltable.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelTable](Excel.modeltable.md)** 
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modeltablecolumn.parent.md
+++ b/api/Excel.modeltablecolumn.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelTableColumn](Excel.modeltablec
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modeltablecolumns.parent.md
+++ b/api/Excel.modeltablecolumns.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelTableColumns](Excel.modeltable
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modeltablenamechange.parent.md
+++ b/api/Excel.modeltablenamechange.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelTableNameChange](Excel.modelta
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modeltablenamechanges.parent.md
+++ b/api/Excel.modeltablenamechanges.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelTableNameChanges](Excel.modelt
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modeltablenames.parent.md
+++ b/api/Excel.modeltablenames.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelTableNames](Excel.modeltablena
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.modeltables.parent.md
+++ b/api/Excel.modeltables.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[ModelTables](Excel.modeltables.md)*
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.pivotvaluecell.parent.md
+++ b/api/Excel.pivotvaluecell.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[PivotValueCell](Excel.pivotvaluecel
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.quickanalysis.parent.md
+++ b/api/Excel.quickanalysis.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[QuickAnalysis](Excel.quickanalysis.
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.sheets.add2.md
+++ b/api/Excel.sheets.add2.md
@@ -32,7 +32,7 @@ _expression_ A variable that represents a **[Sheets](Excel.Sheets.md)** object.
 
 ## Return value
 
-**OBJECT**
+**Object**
 
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Excel.tableobject.parent.md
+++ b/api/Excel.tableobject.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[TableObject](Excel.tableobject.md)*
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.textconnection.parent.md
+++ b/api/Excel.textconnection.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[TextConnection](Excel.TextConnectio
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Excel.timelinestate.parent.md
+++ b/api/Excel.timelinestate.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[TimelineState](Excel.TimelineState.
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.timelineviewstate.parent.md
+++ b/api/Excel.timelineviewstate.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[TimelineViewState](Excel.TimelineVi
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.workbook.pivottables.md
+++ b/api/Excel.workbook.pivottables.md
@@ -28,7 +28,7 @@ _expression_ A variable that represents a **[Workbook](Excel.Workbook.md)** obje
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.worksheetdataconnection.parent.md
+++ b/api/Excel.worksheetdataconnection.parent.md
@@ -23,7 +23,7 @@ _expression_ A variable that represents a **[WorksheetDataConnection](Excel.work
 
 ## Property value
 
-**OBJECT**
+**Object**
 
 
 

--- a/api/Excel.worksheets.add2.md
+++ b/api/Excel.worksheets.add2.md
@@ -32,7 +32,7 @@ _expression_ A variable that represents a **[Worksheets](Excel.Worksheets.md)** 
 
 ## Return value
 
-**OBJECT**
+**Object**
 
 
 


### PR DESCRIPTION
The *Return Value* section of a property/method is sometimes written as all caps "OBJECT" instead of "Object". This is incosistent with the rest of the Excel api reference.