### PR TITLE
Retiring ms.prod metadata values

### DIFF
--- a/F1/cursoronhover-property-access-vbaac10-chm5864
+++ b/F1/cursoronhover-property-access-vbaac10-chm5864
@@ -3,7 +3,7 @@ title: CursorOnHover Property, Access [vbaac10.chm5864]
 keywords: vbaac10.chm5864
 f1_keywords:
 - vbaac10.chm5864
-ms.prod: office
+ms.service: office
 ms.assetid: 6e3be266-4f44-4e55-9834-4db614898a59
 ms.date: 05/17/2023
 ms.localizationpriority: medium

--- a/api/Excel.chartgroup.binscountvalue.md
+++ b/api/Excel.chartgroup.binscountvalue.md
@@ -5,7 +5,6 @@ f1_keywords:
 - vbaxl10.chm568105
 ms.assetid: 933ce137-4421-54c1-e3f7-f51466f6012d
 ms.date: 06/08/2019
-ms.prod: 04/20/2019
 ms.localizationpriority: medium
 ---
 


### PR DESCRIPTION
The ms.prod metadata field is no longer used by the Learn platform. This is a cleanup PR eliminating it from any content that still has it and replacing it with ms.service (and an appropriate value) where needed.