### PR TITLE
Update AcAggregateType documentation to specify the enum applies to M…

### DIFF
--- a/api/Access.AcAggregateType.md
+++ b/api/Access.AcAggregateType.md
@@ -12,7 +12,7 @@ ms.localizationpriority: medium
 
 # AcAggregateType enumeration (Access)
 
-Specifies the type of aggregation to apply to a set of values.
+Specifies the type of aggregation to apply for an Access Modern Chart series.
 
 |Name|Value|Description|
 |:-----|:-----|:-----|


### PR DESCRIPTION
Update AcAggregateType documentation to specify the enum applies to Modern Chart series.  Customers have been getting confused about what this enum is used for