### PR TITLE
Update Access.TextBox.Locked.md

### DIFF
--- a/api/Access.TextBox.Locked.md
+++ b/api/Access.TextBox.Locked.md
@@ -25,26 +25,26 @@ _expression_ A variable that represents a **[TextBox](Access.TextBox.md)** objec
 
 ## Remarks
 
-The default setting of the **Locked** property is **True**. This setting allows editing, adding, and deleting data.
+The default setting of the **Locked** property is **False**. This setting allows editing, adding, and deleting data.
 
-Use the **Locked** property to protect data in a field by making it read-only. For example, you might want a control to only display information without allowing editing, or you might want to lock a control until a specific condition is met.
+Use the **Locked** property to protect data in a field by making it read-only. For example, you might want a textbox to only display information without allowing editing, or you might want to lock a textbox until a specific condition is met.
 
 
 ## Example
 
-The following example toggles the **Enabled** property of a command button and the **Enabled** and **Locked** properties of a control, depending on the type of employee displayed in the current record. If the employee is a manager, the **SalaryDetails** button is enabled and the **PersonalInfo** control is unlocked and enabled.
+The following example toggles the **Enabled** property of a command button and the **Enabled** and **Locked** properties of a textbox, depending on the type of employee displayed in the current record. If the employee is a manager, the **SalaryDetails** button is enabled and the **PersonalInfo** textbox is unlocked and enabled.
 
 ```vb
 Sub Form_Current() 
- If Me!EmployeeType = "Manager" Then 
- Me!SalaryDetails.Enabled = True 
- Me!PersonalInfo.Enabled = True 
- Me!PersonalInfo.Locked = False 
- Else 
- Me!SalaryDetails.Enabled = False 
- Me!PersonalInfo.Enabled = False 
- Me!PersonalInfo.Locked = True 
- End If 
+    If Me!EmployeeType = "Manager" Then 
+        Me!SalaryDetails.Enabled = True 
+        Me!PersonalInfo.Enabled = True 
+        Me!PersonalInfo.Locked = False 
+    Else 
+        Me!SalaryDetails.Enabled = False 
+        Me!PersonalInfo.Enabled = False 
+        Me!PersonalInfo.Locked = True 
+    End If 
 End Sub
 ```
 


### PR DESCRIPTION
Corrected the default setting as this is False, not True. Changed the generic "control" to "textbox" as this is about the TextBox control, and not a generic control of which some (ie. Label) do not expose this property.