### PR TITLE
Add a note to indicate Merge UI related APIs are deprecated

### DIFF
--- a/api/PowerPoint.Options.ShowCoauthoringMergeChanges.md
+++ b/api/PowerPoint.Options.ShowCoauthoringMergeChanges.md
@@ -12,6 +12,8 @@ ms.localizationpriority: medium
 
 
 # Options.ShowCoauthoringMergeChanges property (PowerPoint)
+> [!NOTE] 
+> This object or member has been deprecated, but it remains part of the object model for backward compatibility. You should not use it in new applications.
 
 Returns or sets the show changes mode. Read/write.
 

--- a/api/PowerPoint.Presentation.AcceptAll.md
+++ b/api/PowerPoint.Presentation.AcceptAll.md
@@ -12,6 +12,8 @@ ms.localizationpriority: medium
 
 
 # Presentation.AcceptAll method (PowerPoint)
+> [!NOTE] 
+> This object or member has been deprecated, but it remains part of the object model for backward compatibility. You should not use it in new applications.
 
 Accepts all changes.
 

--- a/api/PowerPoint.Presentation.EndReview.md
+++ b/api/PowerPoint.Presentation.EndReview.md
@@ -12,6 +12,8 @@ ms.localizationpriority: medium
 
 
 # Presentation.EndReview method (PowerPoint)
+> [!NOTE] 
+> This object or member has been deprecated, but it remains part of the object model for backward compatibility. You should not use it in new applications.
 
 Ends the review cycle.
 

--- a/api/PowerPoint.Presentation.InMergeMode.md
+++ b/api/PowerPoint.Presentation.InMergeMode.md
@@ -12,6 +12,8 @@ ms.localizationpriority: medium
 
 
 # Presentation.InMergeMode property (PowerPoint)
+> [!NOTE] 
+> This object or member has been deprecated, but it remains part of the object model for backward compatibility. You should not use it in new applications.
 
 Indicates whether the document window is in merge mode. Read-only
 

--- a/api/PowerPoint.Presentation.MergeWithBaseline.md
+++ b/api/PowerPoint.Presentation.MergeWithBaseline.md
@@ -12,6 +12,8 @@ ms.localizationpriority: medium
 
 
 # Presentation.MergeWithBaseline method (PowerPoint)
+> [!NOTE] 
+> This object or member has been deprecated, but it remains part of the object model for backward compatibility. You should not use it in new applications.
 
 Merges a presentation into another presentation.
 

--- a/api/PowerPoint.Presentation.RejectAll.md
+++ b/api/PowerPoint.Presentation.RejectAll.md
@@ -12,6 +12,8 @@ ms.localizationpriority: medium
 
 
 # Presentation.RejectAll method (PowerPoint)
+> [!NOTE] 
+> This object or member has been deprecated, but it remains part of the object model for backward compatibility. You should not use it in new applications.
 
 Rejects all changes.
 

--- a/api/PowerPoint.presentation.merge.md
+++ b/api/PowerPoint.presentation.merge.md
@@ -10,6 +10,8 @@ ms.localizationpriority: medium
 
 
 # Presentation.Merge method (PowerPoint)
+> [!NOTE] 
+> This object or member has been deprecated, but it remains part of the object model for backward compatibility. You should not use it in new applications.
 
 Merges the changes in one presentation with another.
 


### PR DESCRIPTION
The Merge UI is being removed from PowerPoint and the associated APIs are being deprecated.

This change adds the following note to each of the impacted API pages:
> [!NOTE] 
> This object or member has been deprecated, but it remains part of the object model for backward compatibility. You should not use it in new applications.

The note code was copied from https://github.com/MicrosoftDocs/VBA-Docs/blob/0f230cab161a59c5a2b7c533532023a1f7bdc4cf/api/Excel.ModuleView.md