### PR TITLE
Fix a typo in the `MsoVerticalAnchor` enum

### DIFF
--- a/api/Office.MsoVerticalAnchor.md
+++ b/api/Office.MsoVerticalAnchor.md
@@ -18,7 +18,7 @@ Specifies the vertical alignment of text in a text frame. Used with the **Vertic
 |**msoAnchorBottomBaseLine**|5|Anchors bottom of text string to current position, regardless of text resizing. When you resize text without baseline anchoring, text centers itself on previous position.|
 |**msoAnchorMiddle**|3|Centers text vertically.|
 |**msoAnchorTop**|1|Aligns text to top of text frame.|
-|**msoAnchorTopBaseline**|2|Anchors bottom of text string to current position, regardless of text resizing. When you resize text without baseline anchoring, text centers itself on previous position.|
+|**msoAnchorTopBaseline**|2|Anchors top of text string to current position, regardless of text resizing. When you resize text without baseline anchoring, text centers itself on previous position.|
 |**msoVerticalAnchorMixed**|-2|Return value only; indicates a combination of the other states. |
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]


### PR DESCRIPTION
`msoAnchorTopBaseline` anchors top of text string to current position, not bottom of text