### PR TITLE
`Style.Visibility = True` in Word VBA hides styles

### DIFF
--- a/api/Word.Style.Visibility.md
+++ b/api/Word.Style.Visibility.md
@@ -6,7 +6,7 @@ f1_keywords:
 api_name:
 - Word.Style.Hidden
 ms.assetid: 4afbdfc5-782d-2cb3-33f1-1bb438dd392c
-ms.date: 06/08/2017
+ms.date: 02/06/2025
 ms.localizationpriority: medium
 ---
 

--- a/api/Word.Style.Visibility.md
+++ b/api/Word.Style.Visibility.md
@@ -1,24 +1,24 @@
 ---
-title: Style.Visibility property (Word)
+title: Style.Hidden property (Word)
 keywords: vbawd10.chm153878547
 f1_keywords:
 - vbawd10.chm153878547
 api_name:
-- Word.Style.Visibility
+- Word.Style.Hidden
 ms.assetid: 4afbdfc5-782d-2cb3-33f1-1bb438dd392c
 ms.date: 06/08/2017
 ms.localizationpriority: medium
 ---
 
 
-# Style.Visibility property (Word)
+# Style.Hidden property (Word)
 
- **True** if the specified style is visible as a recommended style in the **Styles** gallery and in the **Styles** task pane. Read/write.
+ **True** if the specified style is hidden as a recommended style in the **Styles** gallery and in the **Styles** task pane. Read/write.
 
 
 ## Syntax
 
-_expression_. `Visibility`
+_expression_. `Hidden`
 
  _expression_ An expression that returns a '[Style](Word.Style.md)' object.
 


### PR DESCRIPTION
`Style.Visibility = True` behaves in an opposite way and rather hides style from pane instead.