### PR TITLE
Remove Double solid formatting option, as it's not supported in the p…

### DIFF
--- a/api/Access.Attachment.BorderStyle.md
+++ b/api/Access.Attachment.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.Attachment.OldBorderStyle.md
+++ b/api/Access.Attachment.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 

--- a/api/Access.BoundObjectFrame.BorderStyle.md
+++ b/api/Access.BoundObjectFrame.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.BoundObjectFrame.OldBorderStyle.md
+++ b/api/Access.BoundObjectFrame.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.CheckBox.BorderStyle.md
+++ b/api/Access.CheckBox.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.CheckBox.OldBorderStyle.md
+++ b/api/Access.CheckBox.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.ComboBox.BorderStyle.md
+++ b/api/Access.ComboBox.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.ComboBox.OldBorderStyle.md
+++ b/api/Access.ComboBox.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.CommandButton.BorderStyle.md
+++ b/api/Access.CommandButton.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.CustomControl.BorderStyle.md
+++ b/api/Access.CustomControl.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.CustomControl.OldBorderStyle.md
+++ b/api/Access.CustomControl.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.Form.DatasheetBorderLineStyle.md
+++ b/api/Access.Form.DatasheetBorderLineStyle.md
@@ -25,7 +25,7 @@ _expression_ A variable that represents a **[Form](Access.Form.md)** object.
 
 ## Remarks
 
-Valid values are between zero and eight. Values greater than eight are ignored; negative values or values above 255 cause an error.
+Valid values are between zero and seven. Values greater than eight are ignored; negative values or values above 255 cause an error.
 
 |Value|Description|
 |:-----|:-----|
@@ -37,7 +37,6 @@ Valid values are between zero and eight. Values greater than eight are ignored; 
 |5|Sparse dots|
 |6|Dash-dot|
 |7|Dash-dot-dot|
-|8|Double solid|
 
 ## Example
 

--- a/api/Access.Form.DatasheetColumnHeaderUnderlineStyle.md
+++ b/api/Access.Form.DatasheetColumnHeaderUnderlineStyle.md
@@ -25,7 +25,7 @@ _expression_ A variable that represents a **[Form](Access.Form.md)** object.
 
 ## Remarks
 
-Valid values are between zero and eight. Values greater than eight are ignored; negative values or values above 255 cause an error.
+Valid values are between zero and seven. Values greater than eight are ignored; negative values or values above 255 cause an error.
 
 |Value|Description|
 |:-----|:-----|
@@ -37,7 +37,6 @@ Valid values are between zero and eight. Values greater than eight are ignored; 
 |5|Sparse dots|
 |6|Dash-dot|
 |7|Dash-dot-dot|
-|8|Double solid|
 
 ## Example
 

--- a/api/Access.Image.BorderStyle.md
+++ b/api/Access.Image.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.Image.OldBorderStyle.md
+++ b/api/Access.Image.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.Label.BorderStyle.md
+++ b/api/Access.Label.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.Label.OldBorderStyle.md
+++ b/api/Access.Label.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.Line.BorderStyle.md
+++ b/api/Access.Line.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.Line.OldBorderStyle.md
+++ b/api/Access.Line.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.ListBox.BorderStyle.md
+++ b/api/Access.ListBox.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.ListBox.OldBorderStyle.md
+++ b/api/Access.ListBox.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.NavigationButton.BorderStyle.md
+++ b/api/Access.NavigationButton.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.NavigationControl.BorderStyle.md
+++ b/api/Access.NavigationControl.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.NavigationControl.OldBorderStyle.md
+++ b/api/Access.NavigationControl.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.ObjectFrame.BorderStyle.md
+++ b/api/Access.ObjectFrame.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.ObjectFrame.OldBorderStyle.md
+++ b/api/Access.ObjectFrame.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.OptionButton.BorderStyle.md
+++ b/api/Access.OptionButton.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.OptionButton.OldBorderStyle.md
+++ b/api/Access.OptionButton.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.OptionGroup.BorderStyle.md
+++ b/api/Access.OptionGroup.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.OptionGroup.OldBorderStyle.md
+++ b/api/Access.OptionGroup.OldBorderStyle.md
@@ -37,8 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
-
 
 ## Example
 

--- a/api/Access.Rectangle.BorderStyle.md
+++ b/api/Access.Rectangle.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.Rectangle.OldBorderStyle.md
+++ b/api/Access.Rectangle.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.Report.BorderStyle.md
+++ b/api/Access.Report.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.report.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.SubForm.BorderStyle.md
+++ b/api/Access.SubForm.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.SubForm.OldBorderStyle.md
+++ b/api/Access.SubForm.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.TabControl.BorderStyle.md
+++ b/api/Access.TabControl.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.TextBox.BorderStyle.md
+++ b/api/Access.TextBox.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.TextBox.OldBorderStyle.md
+++ b/api/Access.TextBox.OldBorderStyle.md
@@ -37,7 +37,6 @@ The **OldBorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 
 ## Example

--- a/api/Access.ToggleButton.BorderStyle.md
+++ b/api/Access.ToggleButton.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 

--- a/api/Access.WebBrowserControl.BorderStyle.md
+++ b/api/Access.WebBrowserControl.BorderStyle.md
@@ -37,7 +37,6 @@ For controls, the **BorderStyle** property uses the following settings.
 |Sparse dots|5|Dotted line with dots spaced far apart|
 |Dash dot|6|Line with a dash-dot combination|
 |Dash dot dot|7|Line with a dash-dot-dot combination|
-|Double solid|8|Double solid lines|
 
 You can set the default for this property by using a control's default control style or the **[DefaultControl](access.form.defaultcontrol.md)** property in Visual Basic.
 


### PR DESCRIPTION
Remove Double solid formatting option, as it's not supported in the product (doesn't appear in formatting options dropdown and doesn't work in VBA) and I also don't see mention of it in our code

NOTE: This was first reported by one of our MVPs