### PR TITLE
Correct Shape.Glow property documentation

### DIFF
--- a/api/PowerPoint.Shape.Glow.md
+++ b/api/PowerPoint.Shape.Glow.md
@@ -13,7 +13,7 @@ ms.localizationpriority: medium
 
 # Shape.Glow property (PowerPoint)
 
-Returns a  **[GlowFormat](glowformat-object-office.md)** object that contains glow formatting properties for the specified shape. Read-only.
+Returns a  **[GlowFormat](Office.GlowFormat.md)** object that contains glow formatting properties for the specified shape. Read-only.
 
 
 ## Syntax

--- a/api/PowerPoint.Shape.Glow.md
+++ b/api/PowerPoint.Shape.Glow.md
@@ -13,7 +13,7 @@ ms.localizationpriority: medium
 
 # Shape.Glow property (PowerPoint)
 
-Returns the glow format for the specified shape. Read-only.
+Returns a  **[GlowFormat](glowformat-object-office.md)** object that contains glow formatting properties for the specified shape. Read-only.
 
 
 ## Syntax
@@ -25,7 +25,22 @@ _expression_ A variable that represents a **[Shape](PowerPoint.Shape.md)** objec
 
 ## Return value
 
-MsoGlowType
+GlowFormat
+
+
+## Example
+
+This example sets the color, radius, and transparency for the glow of the second shape on the second slide in a PowerPoint presentation:
+
+
+```
+With ActivePresentation.Slides(2).Shapes(2).Glow
+    .Color.RGB = RGB(128, 0, 0)
+    .Radius = 10
+    .Transparency = 0.5
+End With 
+
+```
 
 
 ## See also


### PR DESCRIPTION
Updated the Glow property documentation to specify that it returns a GlowFormat object rather than an MsoGlowType and added an example for setting glow properties.