### PR TITLE
fix(api/office): Correct descriptions for MsoShadowTypes

### DIFF
--- a/api/Office.MsoShadowType.md
+++ b/api/Office.MsoShadowType.md
@@ -15,48 +15,48 @@ Specifies the type of shadow displayed with a shape.The **msoShadowType** consta
 |Name|Value|Description|
 |:-----|:-----|:-----|
 |**msoShadowMixed**|-2|Not supported |
-|**msoShadow1**|1|First shadow type |
-|**msoShadow2**|2|Second shadow type |
-|**msoShadow3**|3|Third shadow type |
-|**msoShadow4**|4|Fourth shadow type |
-|**msoShadow5**|5|Fifth shadow type |
-|**msoShadow6**|6|Sixth shadow type |
-|**msoShadow7**|7|Seventh shadow type |
-|**msoShadow8**|8|Eighth shadow type |
-|**msoShadow9**|9|Ninth shadow type |
-|**msoShadow10**|10|Tenth shadow type |
-|**msoShadow11**|11|Eleventh shadow type |
-|**msoShadow12**|12|Twelfth shadow type |
-|**msoShadow13**|13|Thirteenth shadow type |
-|**msoShadow14**|14|Fourteenth shadow type |
-|**msoShadow15**|15|Fifteenth shadow type |
-|**msoShadow16**|16|Sixteenth shadow type |
-|**msoShadow17**|17|Seventeenth shadow type |
-|**msoShadow18**|18|Eighteenth shadow type |
-|**msoShadow19**|19|Nineteenth shadow type |
-|**msoShadow20**|20|Twentieth shadow type |
-|**msoShadow21**|21|Twenty-first shadow type. |
-|**msoShadow22**|22|Twenty-second shadow type. |
-|**msoShadow23**|23|Twenty-third shadow type. |
-|**msoShadow24**|24|Twenty-fourth shadow type. |
-|**msoShadow25**|25|Twenty-fifth shadow type. |
-|**msoShadow26**|26|Twenty-sixth shadow type. |
-|**msoShadow27**|27|Twenty-seventh shadow type. |
-|**msoShadow28**|28|Twenty-eighth shadow type. |
-|**msoShadow29**|29|Twenty-ninth shadow type. |
-|**msoShadow30**|30|Thirtieth shadow type.  |
-|**msoShadow31**|31|Thirty-first shadow type. |
-|**msoShadow32**|32|Thirty-second shadow type. |
-|**msoShadow33**|33|Thirty-third shadow type. |
-|**msoShadow34**|34|Thirty-fourth shadow type. |
-|**msoShadow35**|35|Thirty-fifth shadow type. |
-|**msoShadow36**|36|Thirty-sixth shadow type. |
-|**msoShadow37**|37|Thirty-seventh shadow type. |
-|**msoShadow38**|38|Thirty-eighth shadow type. |
-|**msoShadow39**|39|Thirty-ninth shadow type. |
-|**msoShadow40**|40|Fourtieth shadow type.  |
-|**msoShadow41**|41|Fourty-first shadow type. |
-|**msoShadow42**|42|Fourty-second shadow type. |
-|**msoShadow43**|43|Fourty-third shadow type. |
+|**msoShadow1**|1|First shadow type. Represents a solid outer shadow offset to the top-left of the shape. |
+|**msoShadow2**|2|Second shadow type. Represents a solid outer shadow offset to the top-right of the shape. |
+|**msoShadow3**|3|Third shadow type. Represents a solid perspective shadow in the upper-left of the shape. |
+|**msoShadow4**|4|Fourth shadow type. Represents a solid perspective shadow in the upper-right of the shape. |
+|**msoShadow5**|5|Fifth shadow type. Represents a solid outer shadow offset to the bottom-left of the shape. |
+|**msoShadow6**|6|Sixth shadow type. Represents a solid outer shadow offset to the bottom-right of the shape. |
+|**msoShadow7**|7|Seventh shadow type. Represents a solid perspective shadow in the lower-left of the shape. |
+|**msoShadow8**|8|Eighth shadow type. Represents a solid perspective shadow in the lower-right of the shape. |
+|**msoShadow9**|9|Ninth shadow type. Represents a solid small outer shadow offset to the top-left of the shape. |
+|**msoShadow10**|10|Tenth shadow type. Represents a solid large outer shadow offset to the top-left of the shape. |
+|**msoShadow11**|11|Eleventh shadow type. Represents a solid perspective shadow in the upper-left of the shape, identical to msoShadow3. |
+|**msoShadow12**|12|Twelfth shadow type. Represents a solid perspective shadow in the upper-right of the shape, identical to msoShadow4. |
+|**msoShadow13**|13|Thirteenth shadow type. Represents a solid double outer shadow offset to the top-left of the shape. |
+|**msoShadow14**|14|Fourteenth shadow type. Represents a solid very small outer shadow offset to the bottom-right of the shape. |
+|**msoShadow15**|15|Fifteenth shadow type. Represents a solid perspective shadow in the lower-left of the shape, identical to msoShadow7. |
+|**msoShadow16**|16|Sixteenth shadow type. Represents a solid perspective shadow in the lower-right of the shape, identical to msoShadow8. |
+|**msoShadow17**|17|Seventeenth shadow type. Represents a solid outer shadow offset to the top-left of the shape. |
+|**msoShadow18**|18|Eighteenth shadow type. Represents a solid very small double outer shadow offset to the top-left and bottom-right of the shape. |
+|**msoShadow19**|19|Nineteenth shadow type. Represents no shadow. |
+|**msoShadow20**|20|Twentieth shadow type. Represents a solid outer shadow offset to the bottom of the shape. |
+|**msoShadow21**|21|Twenty-first shadow type. Represents a soft outer shadow offset to the bottom-right of the shape. |
+|**msoShadow22**|22|Twenty-second shadow type. Represents a soft outer shadow offset to the bottom of the shape. |
+|**msoShadow23**|23|Twenty-third shadow type. Represents a soft outer shadow offset to the bottom-left of the shape. |
+|**msoShadow24**|24|Twenty-fourth shadow type. Represents a soft outer shadow offset to the right of the shape. |
+|**msoShadow25**|25|Twenty-fifth shadow type. Represents a soft outer shadow offset to the center of the shape. |
+|**msoShadow26**|26|Twenty-sixth shadow type. Represents a soft outer shadow offset to the left of the shape. |
+|**msoShadow27**|27|Twenty-seventh shadow type. Represents a soft outer shadow offset to the top-right of the shape. |
+|**msoShadow28**|28|Twenty-eighth shadow type. Represents a soft outer shadow offset to the top of the shape. |
+|**msoShadow29**|29|Twenty-ninth shadow type. Represents a soft outer shadow offset to the top-left of the shape. |
+|**msoShadow30**|30|Thirtieth shadow type. Represents an inner shadow offset to the top-left of the shape. |
+|**msoShadow31**|31|Thirty-first shadow type. Represents an inner shadow offset to the top of the shape. |
+|**msoShadow32**|32|Thirty-second shadow type. Represents an inner shadow offset to the top-right of the shape. |
+|**msoShadow33**|33|Thirty-third shadow type. Represents an inner shadow offset to the left of the shape. |
+|**msoShadow34**|34|Thirty-fourth shadow type. Represents an inner shadow offset to the center of the shape. |
+|**msoShadow35**|35|Thirty-fifth shadow type. Represents an inner shadow offset to the right of the shape. |
+|**msoShadow36**|36|Thirty-sixth shadow type. Represents an inner shadow offset to the bottom-left of the shape. |
+|**msoShadow37**|37|Thirty-seventh shadow type. Represents an inner shadow offset to the bottom of the shape. |
+|**msoShadow38**|38|Thirty-eighth shadow type. Represents an inner shadow offset to the bottom-right of the shape. |
+|**msoShadow39**|39|Thirty-ninth shadow type. Represents a soft perspective shadow in the upper-left of the shape. |
+|**msoShadow40**|40|Fourtieth shadow type. Represents a soft perspective shadow in the upper-right of the shape. |
+|**msoShadow41**|41|Fourty-first shadow type. Represents a soft perspective shadow in the bottom of the shape. |
+|**msoShadow42**|42|Fourty-second shadow type. Represents a soft perspective shadow in the lower-left of the shape. |
+|**msoShadow43**|43|Fourty-third shadow type. Represents a soft perspective shadow in the lower-right of the shape. |
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Office.MsoShadowType.md
+++ b/api/Office.MsoShadowType.md
@@ -14,7 +14,16 @@ Specifies the type of shadow displayed with a shape.The **msoShadowType** consta
 
 |Name|Value|Description|
 |:-----|:-----|:-----|
+|**msoShadowMixed**|-2|Not supported |
 |**msoShadow1**|1|First shadow type |
+|**msoShadow2**|2|Second shadow type |
+|**msoShadow3**|3|Third shadow type |
+|**msoShadow4**|4|Fourth shadow type |
+|**msoShadow5**|5|Fifth shadow type |
+|**msoShadow6**|6|Sixth shadow type |
+|**msoShadow7**|7|Seventh shadow type |
+|**msoShadow8**|8|Eighth shadow type |
+|**msoShadow9**|9|Ninth shadow type |
 |**msoShadow10**|10|Tenth shadow type |
 |**msoShadow11**|11|Eleventh shadow type |
 |**msoShadow12**|12|Twelfth shadow type |
@@ -25,15 +34,6 @@ Specifies the type of shadow displayed with a shape.The **msoShadowType** consta
 |**msoShadow17**|17|Seventeenth shadow type |
 |**msoShadow18**|18|Eighteenth shadow type |
 |**msoShadow19**|19|Nineteenth shadow type |
-|**msoShadow2**|2|Second shadow type |
 |**msoShadow20**|20|Twentieth shadow type |
-|**msoShadow3**|3|Third shadow type |
-|**msoShadow4**|4|Fourth shadow type |
-|**msoShadow5**|5|Fifth shadow type |
-|**msoShadow6**|6|Sixth shadow type |
-|**msoShadow7**|7|Seventh shadow type |
-|**msoShadow8**|8|Eighth shadow type |
-|**msoShadow9**|9|Ninth shadow type |
-|**msoShadowMixed**|-2|Not supported |
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Office.MsoShadowType.md
+++ b/api/Office.MsoShadowType.md
@@ -17,22 +17,22 @@ Specifies the type of shadow displayed with a shape.The **msoShadowType** consta
 |**msoShadowMixed**|-2|Not supported |
 |**msoShadow1**|1|First shadow type. Represents a solid outer shadow offset to the top-left of the shape. |
 |**msoShadow2**|2|Second shadow type. Represents a solid outer shadow offset to the top-right of the shape. |
-|**msoShadow3**|3|Third shadow type. Represents a solid perspective shadow in the upper-left of the shape. |
-|**msoShadow4**|4|Fourth shadow type. Represents a solid perspective shadow in the upper-right of the shape. |
+|**msoShadow3**|3|Third shadow type. Represents a solid perspective shadow at the upper-left of the shape. |
+|**msoShadow4**|4|Fourth shadow type. Represents a solid perspective shadow at the upper-right of the shape. |
 |**msoShadow5**|5|Fifth shadow type. Represents a solid outer shadow offset to the bottom-left of the shape. |
 |**msoShadow6**|6|Sixth shadow type. Represents a solid outer shadow offset to the bottom-right of the shape. |
-|**msoShadow7**|7|Seventh shadow type. Represents a solid perspective shadow in the lower-left of the shape. |
-|**msoShadow8**|8|Eighth shadow type. Represents a solid perspective shadow in the lower-right of the shape. |
-|**msoShadow9**|9|Ninth shadow type. Represents a solid small outer shadow offset to the top-left of the shape. |
-|**msoShadow10**|10|Tenth shadow type. Represents a solid large outer shadow offset to the top-left of the shape. |
-|**msoShadow11**|11|Eleventh shadow type. Represents a solid perspective shadow in the upper-left of the shape, identical to msoShadow3. |
-|**msoShadow12**|12|Twelfth shadow type. Represents a solid perspective shadow in the upper-right of the shape, identical to msoShadow4. |
-|**msoShadow13**|13|Thirteenth shadow type. Represents a solid double outer shadow offset to the top-left of the shape. |
-|**msoShadow14**|14|Fourteenth shadow type. Represents a solid very small outer shadow offset to the bottom-right of the shape. |
-|**msoShadow15**|15|Fifteenth shadow type. Represents a solid perspective shadow in the lower-left of the shape, identical to msoShadow7. |
-|**msoShadow16**|16|Sixteenth shadow type. Represents a solid perspective shadow in the lower-right of the shape, identical to msoShadow8. |
-|**msoShadow17**|17|Seventeenth shadow type. Represents a solid very small double outer shadow offset to the bottom-right and top-left of the shape. |
-|**msoShadow18**|18|Eighteenth shadow type. Represents a solid very small double outer shadow offset to the top-left and bottom-right of the shape. |
+|**msoShadow7**|7|Seventh shadow type. Represents a solid perspective shadow at the lower-left of the shape. |
+|**msoShadow8**|8|Eighth shadow type. Represents a solid perspective shadow at the lower-right of the shape. |
+|**msoShadow9**|9|Ninth shadow type. Represents a solid compact outer shadow offset to the top-left of the shape. |
+|**msoShadow10**|10|Tenth shadow type. Represents an enlarged solid outer shadow offset to the top-left of the shape. |
+|**msoShadow11**|11|Eleventh shadow type. Represents a solid perspective shadow at the upper-left of the shape, identical to msoShadow3. |
+|**msoShadow12**|12|Twelfth shadow type. Represents a solid perspective shadow at the upper-right of the shape, identical to msoShadow4. |
+|**msoShadow13**|13|Thirteenth shadow type. Represents a solid layered outer shadow offset to the top-left of the shape. |
+|**msoShadow14**|14|Fourteenth shadow type. Represents a compact solid outer shadow offset to the bottom-right of the shape. |
+|**msoShadow15**|15|Fifteenth shadow type. Represents a solid perspective shadow at the lower-left of the shape, identical to msoShadow7. |
+|**msoShadow16**|16|Sixteenth shadow type. Represents a solid perspective shadow at the lower-right of the shape, identical to msoShadow8. |
+|**msoShadow17**|17|Seventeenth shadow type. Represents a compact solid dual-offset outer shadow offset to the bottom-right and top-left of the shape. |
+|**msoShadow18**|18|Eighteenth shadow type. Represents a compact solid dual-offset outer shadow offset to the top-left and bottom-right of the shape. |
 |**msoShadow19**|19|Nineteenth shadow type. Represents no shadow. |
 |**msoShadow20**|20|Twentieth shadow type. Represents a solid outer shadow offset to the bottom of the shape. |
 |**msoShadow21**|21|Twenty-first shadow type. Represents a soft outer shadow offset to the bottom-right of the shape. |
@@ -53,10 +53,10 @@ Specifies the type of shadow displayed with a shape.The **msoShadowType** consta
 |**msoShadow36**|36|Thirty-sixth shadow type. Represents an inner shadow offset to the bottom-left of the shape. |
 |**msoShadow37**|37|Thirty-seventh shadow type. Represents an inner shadow offset to the bottom of the shape. |
 |**msoShadow38**|38|Thirty-eighth shadow type. Represents an inner shadow offset to the bottom-right of the shape. |
-|**msoShadow39**|39|Thirty-ninth shadow type. Represents a soft perspective shadow in the upper-left of the shape. |
-|**msoShadow40**|40|Fourtieth shadow type. Represents a soft perspective shadow in the upper-right of the shape. |
-|**msoShadow41**|41|Fourty-first shadow type. Represents a soft perspective shadow in the bottom of the shape. |
-|**msoShadow42**|42|Fourty-second shadow type. Represents a soft perspective shadow in the lower-left of the shape. |
-|**msoShadow43**|43|Fourty-third shadow type. Represents a soft perspective shadow in the lower-right of the shape. |
+|**msoShadow39**|39|Thirty-ninth shadow type. Represents a soft perspective shadow at the upper-left of the shape. |
+|**msoShadow40**|40|Fourtieth shadow type. Represents a soft perspective shadow at the upper-right of the shape. |
+|**msoShadow41**|41|Fourty-first shadow type. Represents a soft perspective shadow at the bottom of the shape. |
+|**msoShadow42**|42|Fourty-second shadow type. Represents a soft perspective shadow at the lower-left of the shape. |
+|**msoShadow43**|43|Fourty-third shadow type. Represents a soft perspective shadow at the lower-right of the shape. |
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Office.MsoShadowType.md
+++ b/api/Office.MsoShadowType.md
@@ -35,5 +35,28 @@ Specifies the type of shadow displayed with a shape.The **msoShadowType** consta
 |**msoShadow18**|18|Eighteenth shadow type |
 |**msoShadow19**|19|Nineteenth shadow type |
 |**msoShadow20**|20|Twentieth shadow type |
+|**msoShadow21**|21|Twenty-first shadow type. |
+|**msoShadow22**|22|Twenty-second shadow type. |
+|**msoShadow23**|23|Twenty-third shadow type. |
+|**msoShadow24**|24|Twenty-fourth shadow type. |
+|**msoShadow25**|25|Twenty-fifth shadow type. |
+|**msoShadow26**|26|Twenty-sixth shadow type. |
+|**msoShadow27**|27|Twenty-seventh shadow type. |
+|**msoShadow28**|28|Twenty-eighth shadow type. |
+|**msoShadow29**|29|Twenty-ninth shadow type. |
+|**msoShadow30**|30|Thirtieth shadow type.  |
+|**msoShadow31**|31|Thirty-first shadow type. |
+|**msoShadow32**|32|Thirty-second shadow type. |
+|**msoShadow33**|33|Thirty-third shadow type. |
+|**msoShadow34**|34|Thirty-fourth shadow type. |
+|**msoShadow35**|35|Thirty-fifth shadow type. |
+|**msoShadow36**|36|Thirty-sixth shadow type. |
+|**msoShadow37**|37|Thirty-seventh shadow type. |
+|**msoShadow38**|38|Thirty-eighth shadow type. |
+|**msoShadow39**|39|Thirty-ninth shadow type. |
+|**msoShadow40**|40|Fourtieth shadow type.  |
+|**msoShadow41**|41|Fourty-first shadow type. |
+|**msoShadow42**|42|Fourty-second shadow type. |
+|**msoShadow43**|43|Fourty-third shadow type. |
 
 [!include[Support and feedback](~/includes/feedback-boilerplate.md)]

--- a/api/Office.MsoShadowType.md
+++ b/api/Office.MsoShadowType.md
@@ -31,7 +31,7 @@ Specifies the type of shadow displayed with a shape.The **msoShadowType** consta
 |**msoShadow14**|14|Fourteenth shadow type. Represents a solid very small outer shadow offset to the bottom-right of the shape. |
 |**msoShadow15**|15|Fifteenth shadow type. Represents a solid perspective shadow in the lower-left of the shape, identical to msoShadow7. |
 |**msoShadow16**|16|Sixteenth shadow type. Represents a solid perspective shadow in the lower-right of the shape, identical to msoShadow8. |
-|**msoShadow17**|17|Seventeenth shadow type. Represents a solid outer shadow offset to the top-left of the shape. |
+|**msoShadow17**|17|Seventeenth shadow type. Represents a solid very small double outer shadow offset to the bottom-right and top-left of the shape. |
 |**msoShadow18**|18|Eighteenth shadow type. Represents a solid very small double outer shadow offset to the top-left and bottom-right of the shape. |
 |**msoShadow19**|19|Nineteenth shadow type. Represents no shadow. |
 |**msoShadow20**|20|Twentieth shadow type. Represents a solid outer shadow offset to the bottom of the shape. |


### PR DESCRIPTION
The Office.MsoShadowType file was missing types 21 to 43. These have been added and the entries have been re-ordered sequentially.

The descriptions of each entry have also been updated to include the effect of applying each type. The effect of each type was investigated by creating a rectangle shape in PowerPoint and applying each type in turn by using the following line.

```vba
ActivePresentation.Slides(1).Shapes(1).Shadow.Type = msoShadow1
```
The attached [msoShadowTypes.zip](https://github.com/user-attachments/files/27051123/msoShadowTypes.zip) includes screenshots of the shape after each shadow type was applied, in case you would like to validate the descriptions without having to apply each shadow type.